### PR TITLE
[#17172827] refactor operation code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ NotificationChannelStatusValue -> lib/api/definitions/NotificationChannelStatusV
 ...
 done
 ```
+
+### Requirements
+
+* `node` version >= 10.8.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2018",
+    "lib": ["es2018"],
     "rootDir": "src",
     "outDir": "dist",
     "module": "commonjs",


### PR DESCRIPTION
This PR is a subset of the refactoring needed by this module in order to allow more feature to be developed. Scope of these changes:

1. Change build target to `es2018` and specify node compatibility in docs
2. Begin removing all the assignments by creating new values instead  (example: https://github.com/pagopa/io-utils/compare/17172827-reduce-cognitive-complexity?expand=1#diff-fcde051fbe51f06e85d21aa14217ee15R199)
3. Begin reducing the complexity of operation code generation, by moving parsing mechanisms outside the main function