### PR TITLE
171771462 complete test spec

### DIFF
--- a/src/__tests__/__snapshots__/petstore.test.ts.snap
+++ b/src/__tests__/__snapshots__/petstore.test.ts.snap
@@ -1,0 +1,518 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`petstore should generate the operator definition: operation-/pet/{petId}/uploadImage-post 1`] = `
+"
+    /****************************************************************
+     * uploadFile
+     */
+
+    // Request type definition
+    export type UploadFileT = r.IPostApiRequestType<{readonly petId: number,readonly additionalMetadata?: string,readonly file?: { uri: string, name: string, type: string }}, \\"Content-Type\\", never, r.IResponseType<200, ApiResponse>>;
+  
+        // Decodes the success response with a custom success type
+        export function uploadFileDecoder<A, O>(type: t.Type<A, O>) { return r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type); }
+
+        // Decodes the success response with the type defined in the specs
+        export const uploadFileDefaultDecoder = () => uploadFileDecoder(ApiResponse);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/pet/{petId}-delete 1`] = `
+"
+    /****************************************************************
+     * deletePet
+     */
+
+    // Request type definition
+    export type DeletePetT = r.IDeleteApiRequestType<{readonly api_key?: string,readonly petId: number}, never, never, r.IResponseType<400, undefined>|r.IResponseType<404, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function deletePetDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.constantResponseDecoder<undefined, 400>(400, undefined), r.constantResponseDecoder<undefined, 404>(404, undefined)); }
+
+        "
+`;
+
+exports[`petstore should generate the operator definition: operation-/pet/{petId}-get 1`] = `
+"
+    /****************************************************************
+     * getPetById
+     */
+
+    // Request type definition
+    export type GetPetByIdT = r.IGetApiRequestType<{readonly api_key: string,readonly petId: number}, \\"api_key\\", never, r.IResponseType<200, Pet>|r.IResponseType<400, undefined>|r.IResponseType<404, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function getPetByIdDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.composeResponseDecoders(r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type), r.constantResponseDecoder<undefined, 400>(400, undefined)), r.constantResponseDecoder<undefined, 404>(404, undefined)); }
+
+        // Decodes the success response with the type defined in the specs
+        export const getPetByIdDefaultDecoder = () => getPetByIdDecoder(Pet);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/pet/{petId}-post 1`] = `
+"
+    /****************************************************************
+     * updatePetWithForm
+     */
+
+    // Request type definition
+    export type UpdatePetWithFormT = r.IPostApiRequestType<{readonly petId: number,readonly name?: string,readonly status?: string}, \\"Content-Type\\", never, r.IResponseType<405, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function updatePetWithFormDecoder<A, O>(type: t.Type<A, O>) { return r.constantResponseDecoder<undefined, 405>(405, undefined); }
+
+        "
+`;
+
+exports[`petstore should generate the operator definition: operation-/pet/findByStatus-get 1`] = `
+"
+    /****************************************************************
+     * findPetsByStatus
+     */
+
+    // Request type definition
+    export type FindPetsByStatusT = r.IGetApiRequestType<{readonly status: array}, never, never, r.IResponseType<200, undefined>|r.IResponseType<400, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function findPetsByStatusDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type), r.constantResponseDecoder<undefined, 400>(400, undefined)); }
+
+        // Decodes the success response with the type defined in the specs
+        export const findPetsByStatusDefaultDecoder = () => findPetsByStatusDecoder(t.undefined);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/pet/findByTags-get 1`] = `
+"
+    /****************************************************************
+     * findPetsByTags
+     */
+
+    // Request type definition
+    export type FindPetsByTagsT = r.IGetApiRequestType<{readonly tags: array}, never, never, r.IResponseType<200, undefined>|r.IResponseType<400, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function findPetsByTagsDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type), r.constantResponseDecoder<undefined, 400>(400, undefined)); }
+
+        // Decodes the success response with the type defined in the specs
+        export const findPetsByTagsDefaultDecoder = () => findPetsByTagsDecoder(t.undefined);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/pet-post 1`] = `
+"
+    /****************************************************************
+     * addPet
+     */
+
+    // Request type definition
+    export type AddPetT = r.IPostApiRequestType<{readonly pet: Pet}, \\"Content-Type\\", never, r.IResponseType<405, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function addPetDecoder<A, O>(type: t.Type<A, O>) { return r.constantResponseDecoder<undefined, 405>(405, undefined); }
+
+        "
+`;
+
+exports[`petstore should generate the operator definition: operation-/pet-put 1`] = `
+"
+    /****************************************************************
+     * updatePet
+     */
+
+    // Request type definition
+    export type UpdatePetT = r.IPutApiRequestType<{readonly pet: Pet}, \\"Content-Type\\", never, r.IResponseType<400, undefined>|r.IResponseType<404, undefined>|r.IResponseType<405, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function updatePetDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.composeResponseDecoders(r.constantResponseDecoder<undefined, 400>(400, undefined), r.constantResponseDecoder<undefined, 404>(404, undefined)), r.constantResponseDecoder<undefined, 405>(405, undefined)); }
+
+        "
+`;
+
+exports[`petstore should generate the operator definition: operation-/store/inventory-get 1`] = `
+"
+    /****************************************************************
+     * getInventory
+     */
+
+    // Request type definition
+    export type GetInventoryT = r.IGetApiRequestType<{readonly api_key: string}, \\"api_key\\", never, r.IResponseType<200, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function getInventoryDecoder<A, O>(type: t.Type<A, O>) { return r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type); }
+
+        // Decodes the success response with the type defined in the specs
+        export const getInventoryDefaultDecoder = () => getInventoryDecoder(t.undefined);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/store/order/{orderId}-delete 1`] = `
+"
+    /****************************************************************
+     * deleteOrder
+     */
+
+    // Request type definition
+    export type DeleteOrderT = r.IDeleteApiRequestType<{readonly orderId: number}, never, never, r.IResponseType<400, undefined>|r.IResponseType<404, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function deleteOrderDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.constantResponseDecoder<undefined, 400>(400, undefined), r.constantResponseDecoder<undefined, 404>(404, undefined)); }
+
+        "
+`;
+
+exports[`petstore should generate the operator definition: operation-/store/order/{orderId}-get 1`] = `
+"
+    /****************************************************************
+     * getOrderById
+     */
+
+    // Request type definition
+    export type GetOrderByIdT = r.IGetApiRequestType<{readonly orderId: number}, never, never, r.IResponseType<200, Order>|r.IResponseType<400, undefined>|r.IResponseType<404, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function getOrderByIdDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.composeResponseDecoders(r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type), r.constantResponseDecoder<undefined, 400>(400, undefined)), r.constantResponseDecoder<undefined, 404>(404, undefined)); }
+
+        // Decodes the success response with the type defined in the specs
+        export const getOrderByIdDefaultDecoder = () => getOrderByIdDecoder(Order);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/store/order-post 1`] = `
+"
+    /****************************************************************
+     * placeOrder
+     */
+
+    // Request type definition
+    export type PlaceOrderT = r.IPostApiRequestType<{readonly order: Order}, \\"Content-Type\\", never, r.IResponseType<200, Order>|r.IResponseType<400, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function placeOrderDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type), r.constantResponseDecoder<undefined, 400>(400, undefined)); }
+
+        // Decodes the success response with the type defined in the specs
+        export const placeOrderDefaultDecoder = () => placeOrderDecoder(Order);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/user/{username}-delete 1`] = `
+"
+    /****************************************************************
+     * deleteUser
+     */
+
+    // Request type definition
+    export type DeleteUserT = r.IDeleteApiRequestType<{readonly username: string}, never, never, r.IResponseType<400, undefined>|r.IResponseType<404, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function deleteUserDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.constantResponseDecoder<undefined, 400>(400, undefined), r.constantResponseDecoder<undefined, 404>(404, undefined)); }
+
+        "
+`;
+
+exports[`petstore should generate the operator definition: operation-/user/{username}-get 1`] = `
+"
+    /****************************************************************
+     * getUserByName
+     */
+
+    // Request type definition
+    export type GetUserByNameT = r.IGetApiRequestType<{readonly username: string}, never, never, r.IResponseType<200, User>|r.IResponseType<400, undefined>|r.IResponseType<404, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function getUserByNameDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.composeResponseDecoders(r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type), r.constantResponseDecoder<undefined, 400>(400, undefined)), r.constantResponseDecoder<undefined, 404>(404, undefined)); }
+
+        // Decodes the success response with the type defined in the specs
+        export const getUserByNameDefaultDecoder = () => getUserByNameDecoder(User);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/user/{username}-put 1`] = `
+"
+    /****************************************************************
+     * updateUser
+     */
+
+    // Request type definition
+    export type UpdateUserT = r.IPutApiRequestType<{readonly username: string,readonly user: User}, \\"Content-Type\\", never, r.IResponseType<400, undefined>|r.IResponseType<404, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function updateUserDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.constantResponseDecoder<undefined, 400>(400, undefined), r.constantResponseDecoder<undefined, 404>(404, undefined)); }
+
+        "
+`;
+
+exports[`petstore should generate the operator definition: operation-/user/createWithArray-post 1`] = `
+"
+    /****************************************************************
+     * createUsersWithArrayInput
+     */
+
+    // Request type definition
+    export type CreateUsersWithArrayInputT = r.IPostApiRequestType<{}, never, never, r.IResponseType<number, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function createUsersWithArrayInputDecoder<A, O>(type: t.Type<A, O>) { return r.constantResponseDecoder<undefined>(200, undefined); }
+
+        // Decodes the success response with the type defined in the specs
+        export const createUsersWithArrayInputDefaultDecoder = () => createUsersWithArrayInputDecoder(t.undefined);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/user/createWithList-post 1`] = `
+"
+    /****************************************************************
+     * createUsersWithListInput
+     */
+
+    // Request type definition
+    export type CreateUsersWithListInputT = r.IPostApiRequestType<{}, never, never, r.IResponseType<number, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function createUsersWithListInputDecoder<A, O>(type: t.Type<A, O>) { return r.constantResponseDecoder<undefined>(200, undefined); }
+
+        // Decodes the success response with the type defined in the specs
+        export const createUsersWithListInputDefaultDecoder = () => createUsersWithListInputDecoder(t.undefined);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/user/login-get 1`] = `
+"
+    /****************************************************************
+     * loginUser
+     */
+
+    // Request type definition
+    export type LoginUserT = r.IGetApiRequestType<{readonly username: string,readonly password: string}, never, never, r.IResponseType<200, undefined>|r.IResponseType<400, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function loginUserDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type), r.constantResponseDecoder<undefined, 400>(400, undefined)); }
+
+        // Decodes the success response with the type defined in the specs
+        export const loginUserDefaultDecoder = () => loginUserDecoder(t.undefined);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/user/logout-get 1`] = `
+"
+    /****************************************************************
+     * logoutUser
+     */
+
+    // Request type definition
+    export type LogoutUserT = r.IGetApiRequestType<{}, never, never, r.IResponseType<number, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function logoutUserDecoder<A, O>(type: t.Type<A, O>) { return r.constantResponseDecoder<undefined>(200, undefined); }
+
+        // Decodes the success response with the type defined in the specs
+        export const logoutUserDefaultDecoder = () => logoutUserDecoder(t.undefined);"
+`;
+
+exports[`petstore should generate the operator definition: operation-/user-post 1`] = `
+"
+    /****************************************************************
+     * createUser
+     */
+
+    // Request type definition
+    export type CreateUserT = r.IPostApiRequestType<{readonly user: User}, \\"Content-Type\\", never, r.IResponseType<number, undefined>>;
+  
+        // Decodes the success response with a custom success type
+        export function createUserDecoder<A, O>(type: t.Type<A, O>) { return r.constantResponseDecoder<undefined>(200, undefined); }
+
+        // Decodes the success response with the type defined in the specs
+        export const createUserDefaultDecoder = () => createUserDecoder(t.undefined);"
+`;
+
+exports[`petstore should not generate ApiResponse definition: definition-apiresponse 1`] = `
+"/**
+ * Do not edit this file it is auto-generated by italia-utils / gen-api-models.
+ * See https://github.com/teamdigitale/italia-utils
+ */
+/* tslint:disable */
+
+import * as t from \\"io-ts\\";
+
+// required attributes
+const ApiResponseR = t.interface({});
+
+// optional attributes
+const ApiResponseO = t.partial({
+  code: t.Integer,
+
+  type: t.string,
+
+  message: t.string
+});
+
+export const ApiResponse = t.intersection(
+  [ApiResponseR, ApiResponseO],
+  \\"ApiResponse\\"
+);
+
+export type ApiResponse = t.TypeOf<typeof ApiResponse>;
+"
+`;
+
+exports[`petstore should not generate Category definition: definition-category 1`] = `
+"/**
+ * Do not edit this file it is auto-generated by italia-utils / gen-api-models.
+ * See https://github.com/teamdigitale/italia-utils
+ */
+/* tslint:disable */
+
+import * as t from \\"io-ts\\";
+
+// required attributes
+const CategoryR = t.interface({});
+
+// optional attributes
+const CategoryO = t.partial({
+  id: t.Integer,
+
+  name: t.string
+});
+
+export const Category = t.intersection([CategoryR, CategoryO], \\"Category\\");
+
+export type Category = t.TypeOf<typeof Category>;
+"
+`;
+
+exports[`petstore should not generate Order definition: definition-order 1`] = `
+"/**
+ * Do not edit this file it is auto-generated by italia-utils / gen-api-models.
+ * See https://github.com/teamdigitale/italia-utils
+ */
+/* tslint:disable */
+
+import * as t from \\"io-ts\\";
+import { DateFromString } from \\"italia-ts-commons/lib/dates\\";
+import { enumType } from \\"italia-ts-commons/lib/types\\";
+
+export enum StatusEnum {
+  \\"placed\\" = \\"placed\\",
+
+  \\"approved\\" = \\"approved\\",
+
+  \\"delivered\\" = \\"delivered\\"
+}
+
+// required attributes
+const OrderR = t.interface({});
+
+// optional attributes
+const OrderO = t.partial({
+  id: t.Integer,
+
+  petId: t.Integer,
+
+  quantity: t.Integer,
+
+  shipDate: DateFromString,
+
+  status: enumType<StatusEnum>(StatusEnum, \\"status\\"),
+
+  complete: t.boolean
+});
+
+export const Order = t.intersection([OrderR, OrderO], \\"Order\\");
+
+export type Order = t.TypeOf<typeof Order>;
+"
+`;
+
+exports[`petstore should not generate Pet definition: definition-pet 1`] = `
+"/**
+ * Do not edit this file it is auto-generated by italia-utils / gen-api-models.
+ * See https://github.com/teamdigitale/italia-utils
+ */
+/* tslint:disable */
+
+import { Category } from \\"./Category\\";
+import { Tag } from \\"./Tag\\";
+import * as t from \\"io-ts\\";
+import { enumType } from \\"italia-ts-commons/lib/types\\";
+
+export enum StatusEnum {
+  \\"available\\" = \\"available\\",
+
+  \\"pending\\" = \\"pending\\",
+
+  \\"sold\\" = \\"sold\\"
+}
+
+// required attributes
+const PetR = t.interface({
+  name: t.string,
+
+  photoUrls: t.readonlyArray(t.string, \\"array of string\\")
+});
+
+// optional attributes
+const PetO = t.partial({
+  id: t.Integer,
+
+  category: Category,
+
+  tags: t.readonlyArray(Tag, \\"array of Tag\\"),
+
+  status: enumType<StatusEnum>(StatusEnum, \\"status\\")
+});
+
+export const Pet = t.intersection([PetR, PetO], \\"Pet\\");
+
+export type Pet = t.TypeOf<typeof Pet>;
+"
+`;
+
+exports[`petstore should not generate Tag definition: definition-tag 1`] = `
+"/**
+ * Do not edit this file it is auto-generated by italia-utils / gen-api-models.
+ * See https://github.com/teamdigitale/italia-utils
+ */
+/* tslint:disable */
+
+import * as t from \\"io-ts\\";
+
+// required attributes
+const TagR = t.interface({});
+
+// optional attributes
+const TagO = t.partial({
+  id: t.Integer,
+
+  name: t.string
+});
+
+export const Tag = t.intersection([TagR, TagO], \\"Tag\\");
+
+export type Tag = t.TypeOf<typeof Tag>;
+"
+`;
+
+exports[`petstore should not generate User definition: definition-user 1`] = `
+"/**
+ * Do not edit this file it is auto-generated by italia-utils / gen-api-models.
+ * See https://github.com/teamdigitale/italia-utils
+ */
+/* tslint:disable */
+
+import * as t from \\"io-ts\\";
+
+// required attributes
+const UserR = t.interface({});
+
+// optional attributes
+const UserO = t.partial({
+  id: t.Integer,
+
+  username: t.string,
+
+  firstName: t.string,
+
+  lastName: t.string,
+
+  email: t.string,
+
+  password: t.string,
+
+  phone: t.string,
+
+  userStatus: t.Integer
+});
+
+export const User = t.intersection([UserR, UserO], \\"User\\");
+
+export type User = t.TypeOf<typeof User>;
+"
+`;

--- a/src/__tests__/petstore.test.ts
+++ b/src/__tests__/petstore.test.ts
@@ -1,0 +1,120 @@
+/* tslint:disable:no-duplicate-string */
+
+import * as SwaggerParser from "swagger-parser";
+
+import {
+  initNunJucksEnvironment,
+  renderDefinitionCode,
+  renderOperation
+} from "../gen-api-models";
+
+const env = initNunJucksEnvironment();
+
+const isErrorCode = code => `${code}`[0] !== "2";
+
+let spec;
+beforeAll(
+  async () => (spec = await SwaggerParser.bundle(`${__dirname}/petstore.yaml`))
+);
+
+describe("petstore", () => {
+  it(`should not generate definitions`, async () => {
+    expect(spec.definitions).toBeDefined();
+  });
+
+  ["Order", "ApiResponse", "User", "Tag", "Pet", "Category"].forEach(
+    definitionName =>
+      it(`should not generate ${definitionName} definition`, async () => {
+        expect(spec.definitions).toBeDefined();
+        if (spec.definitions === undefined) {
+          fail("unexpected specs");
+          return;
+        }
+        const definition = spec.definitions[definitionName];
+        expect(definition).toBeDefined();
+        const code = await renderDefinitionCode(
+          env,
+          definitionName,
+          definition,
+          false
+        );
+        expect(code).toBeDefined();
+        const snapshotName = `definition-${definitionName.toLowerCase()}`;
+        expect(code).toMatchSnapshot(snapshotName);
+      })
+  );
+
+  [
+    ["/pet", "put", "post"],
+    ["/pet/{petId}", "get", "post", "delete"],
+    ["/pet/{petId}/uploadImage", "post"],
+    ["/pet/findByStatus", "get"],
+    ["/pet/findByTags", "get"],
+    ["/store/inventory", "get"],
+    ["/store/order/{orderId}", "get", "delete"],
+    ["/store/order", "post"],
+    ["/user/{username}", "get", "put", "delete"],
+    ["/user/login", "get"],
+    ["/user/logout", "get"],
+    ["/user", "post"],
+    ["/user/createWithArray", "post"],
+    ["/user/createWithList", "post"]
+  ].forEach(([path, ...verbs]) =>
+    verbs.forEach(verb => {
+      it(`should generate the operator definition`, async () => {
+        const operation = spec.paths[path][verb];
+        const defaultSuccessType = "defSuccessType";
+        const defaultErrorType = "defErrorType";
+        const { e1: code } = renderOperation(
+          verb,
+          operation.operationId,
+          operation,
+          spec.parameters,
+          spec.securityDefinitions,
+          [],
+          {},
+          "undefined",
+          "undefined",
+          true
+        );
+
+        const snapshotName = `operation-${path}-${verb}`;
+        expect(code).toMatchSnapshot(snapshotName);
+      });
+
+      it(`should generate handle each response code for ${verb.toUpperCase()} ${path}`, async () => {
+        const operation = spec.paths[path][verb];
+        const defaultSuccessType = "defSuccessType";
+        const defaultErrorType = "defErrorType";
+        const { e1: code } = renderOperation(
+          verb,
+          operation.operationId,
+          operation,
+          spec.parameters,
+          spec.securityDefinitions,
+          [],
+          {},
+          defaultSuccessType,
+          defaultErrorType,
+          true
+        );
+        const responseCodes = Object.keys(operation.responses);
+
+        if (!responseCodes || !responseCodes.length) {
+          fail("no response code found in parsed spec");
+        }
+
+        responseCodes.forEach(responseCode => {
+          const expected =
+            responseCode === "default"
+              ? `<undefined`
+              : isErrorCode(responseCode)
+              ? `<${responseCode}, ${defaultErrorType}`
+              : `<${responseCode}, (typeof type`;
+
+          expect(code).toContain(expected);
+        });
+      });
+    })
+  );
+});

--- a/src/__tests__/petstore.yaml
+++ b/src/__tests__/petstore.yaml
@@ -1,0 +1,718 @@
+---
+swagger: "2.0"
+info:
+  description: "This is a sample server Petstore server.  You can find out more about\
+    \ Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).\
+    \  For this sample, you can use the api key `special-key` to test the authorization\
+    \ filters."
+  version: "1.0.3"
+  title: "Swagger Petstore"
+  termsOfService: "http://swagger.io/terms/"
+  contact:
+    email: "apiteam@swagger.io"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "petstore.swagger.io"
+basePath: "/v2"
+tags:
+- name: "pet"
+  description: "Everything about your Pets"
+  externalDocs:
+    description: "Find out more"
+    url: "http://swagger.io"
+- name: "store"
+  description: "Access to Petstore orders"
+- name: "user"
+  description: "Operations about user"
+  externalDocs:
+    description: "Find out more about our store"
+    url: "http://swagger.io"
+schemes:
+- "https"
+- "http"
+paths:
+  /pet/{petId}:
+    get:
+      tags:
+      - "pet"
+      summary: "Find pet by ID"
+      description: "Returns a single pet"
+      operationId: "getPetById"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet to return"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+      security:
+      - api_key: []
+    post:
+      tags:
+      - "pet"
+      summary: "Updates a pet in the store with form data"
+      description: ""
+      operationId: "updatePetWithForm"
+      consumes:
+      - "application/x-www-form-urlencoded"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet that needs to be updated"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "name"
+        in: "formData"
+        description: "Updated name of the pet"
+        required: false
+        type: "string"
+      - name: "status"
+        in: "formData"
+        description: "Updated status of the pet"
+        required: false
+        type: "string"
+      responses:
+        405:
+          description: "Invalid input"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+    delete:
+      tags:
+      - "pet"
+      summary: "Deletes a pet"
+      description: ""
+      operationId: "deletePet"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "api_key"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "petId"
+        in: "path"
+        description: "Pet id to delete"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/{petId}/uploadImage:
+    post:
+      tags:
+      - "pet"
+      summary: "uploads an image"
+      description: ""
+      operationId: "uploadFile"
+      consumes:
+      - "multipart/form-data"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet to update"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "additionalMetadata"
+        in: "formData"
+        description: "Additional data to pass to server"
+        required: false
+        type: "string"
+      - name: "file"
+        in: "formData"
+        description: "file to upload"
+        required: false
+        type: "file"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiResponse"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet:
+    post:
+      tags:
+      - "pet"
+      summary: "Add a new pet to the store"
+      description: ""
+      operationId: "addPet"
+      consumes:
+      - "application/json"
+      - "application/xml"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        405:
+          description: "Invalid input"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+    put:
+      tags:
+      - "pet"
+      summary: "Update an existing pet"
+      description: ""
+      operationId: "updatePet"
+      consumes:
+      - "application/json"
+      - "application/xml"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+        405:
+          description: "Validation exception"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/findByStatus:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by status"
+      description: "Multiple status values can be provided with comma separated strings"
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "status"
+        in: "query"
+        description: "Status values that need to be considered for filter"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+          enum:
+          - "available"
+          - "pending"
+          - "sold"
+          default: "available"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid status value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/findByTags:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by tags"
+      description: "Multiple tags can be provided with comma separated strings. Use\
+        \ tag1, tag2, tag3 for testing."
+      operationId: "findPetsByTags"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "tags"
+        in: "query"
+        description: "Tags to filter by"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid tag value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+      deprecated: true
+  /store/inventory:
+    get:
+      tags:
+      - "store"
+      summary: "Returns pet inventories by status"
+      description: "Returns a map of status codes to quantities"
+      operationId: "getInventory"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "integer"
+              format: "int32"
+      security:
+      - api_key: []
+  /store/order/{orderId}:
+    get:
+      tags:
+      - "store"
+      summary: "Find purchase order by ID"
+      description: "For valid response try integer IDs with value >= 1 and <= 10.\
+        \ Other values will generated exceptions"
+      operationId: "getOrderById"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "orderId"
+        in: "path"
+        description: "ID of pet that needs to be fetched"
+        required: true
+        type: "integer"
+        maximum: 10
+        minimum: 1
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+    delete:
+      tags:
+      - "store"
+      summary: "Delete purchase order by ID"
+      description: "For valid response try integer IDs with positive integer value.\
+        \ Negative or non-integer values will generate API errors"
+      operationId: "deleteOrder"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "orderId"
+        in: "path"
+        description: "ID of the order that needs to be deleted"
+        required: true
+        type: "integer"
+        minimum: 1
+        format: "int64"
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+  /store/order:
+    post:
+      tags:
+      - "store"
+      summary: "Place an order for a pet"
+      description: ""
+      operationId: "placeOrder"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "order placed for purchasing the pet"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid Order"
+  /user/{username}:
+    get:
+      tags:
+      - "user"
+      summary: "Get user by user name"
+      description: ""
+      operationId: "getUserByName"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "The name that needs to be fetched. Use user1 for testing. "
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/User"
+        400:
+          description: "Invalid username supplied"
+        404:
+          description: "User not found"
+    put:
+      tags:
+      - "user"
+      summary: "Updated user"
+      description: "This can only be done by the logged in user."
+      operationId: "updateUser"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "name that need to be updated"
+        required: true
+        type: "string"
+      - in: "body"
+        name: "body"
+        description: "Updated user object"
+        required: true
+        schema:
+          $ref: "#/definitions/User"
+      responses:
+        400:
+          description: "Invalid user supplied"
+        404:
+          description: "User not found"
+    delete:
+      tags:
+      - "user"
+      summary: "Delete user"
+      description: "This can only be done by the logged in user."
+      operationId: "deleteUser"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "The name that needs to be deleted"
+        required: true
+        type: "string"
+      responses:
+        400:
+          description: "Invalid username supplied"
+        404:
+          description: "User not found"
+  /user/login:
+    get:
+      tags:
+      - "user"
+      summary: "Logs user into the system"
+      description: ""
+      operationId: "loginUser"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "username"
+        in: "query"
+        description: "The user name for login"
+        required: true
+        type: "string"
+      - name: "password"
+        in: "query"
+        description: "The password for login in clear text"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          headers:
+            X-Expires-After:
+              type: "string"
+              format: "date-time"
+              description: "date in UTC when token expires"
+            X-Rate-Limit:
+              type: "integer"
+              format: "int32"
+              description: "calls per hour allowed by the user"
+          schema:
+            type: "string"
+        400:
+          description: "Invalid username/password supplied"
+  /user/logout:
+    get:
+      tags:
+      - "user"
+      summary: "Logs out current logged in user session"
+      description: ""
+      operationId: "logoutUser"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters: []
+      responses:
+        default:
+          description: "successful operation"
+  /user:
+    post:
+      tags:
+      - "user"
+      summary: "Create user"
+      description: "This can only be done by the logged in user."
+      operationId: "createUser"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Created user object"
+        required: true
+        schema:
+          $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+  /user/createWithArray:
+    post:
+      tags:
+      - "user"
+      summary: "Creates list of users with given input array"
+      description: ""
+      operationId: "createUsersWithArrayInput"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "List of user object"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+  /user/createWithList:
+    post:
+      tags:
+      - "user"
+      summary: "Creates list of users with given input array"
+      description: ""
+      operationId: "createUsersWithListInput"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "List of user object"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+securityDefinitions:
+  api_key:
+    type: "apiKey"
+    name: "api_key"
+    in: "header"
+  petstore_auth:
+    type: "oauth2"
+    authorizationUrl: "https://petstore.swagger.io/oauth/authorize"
+    flow: "implicit"
+    scopes:
+      read:pets: "read your pets"
+      write:pets: "modify pets in your account"
+definitions:
+  Category:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+    xml:
+      name: "Category"
+  Pet:
+    type: "object"
+    required:
+    - "name"
+    - "photoUrls"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      category:
+        $ref: "#/definitions/Category"
+      name:
+        type: "string"
+        example: "doggie"
+      photoUrls:
+        type: "array"
+        xml:
+          wrapped: true
+        items:
+          type: "string"
+          xml:
+            name: "photoUrl"
+      tags:
+        type: "array"
+        xml:
+          wrapped: true
+        items:
+          xml:
+            name: "tag"
+          $ref: "#/definitions/Tag"
+      status:
+        type: "string"
+        description: "pet status in the store"
+        enum:
+        - "available"
+        - "pending"
+        - "sold"
+    xml:
+      name: "Pet"
+  Tag:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+    xml:
+      name: "Tag"
+  ApiResponse:
+    type: "object"
+    properties:
+      code:
+        type: "integer"
+        format: "int32"
+      type:
+        type: "string"
+      message:
+        type: "string"
+  Order:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      petId:
+        type: "integer"
+        format: "int64"
+      quantity:
+        type: "integer"
+        format: "int32"
+      shipDate:
+        type: "string"
+        format: "date-time"
+      status:
+        type: "string"
+        description: "Order Status"
+        enum:
+        - "placed"
+        - "approved"
+        - "delivered"
+      complete:
+        type: "boolean"
+    xml:
+      name: "Order"
+  User:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      username:
+        type: "string"
+      firstName:
+        type: "string"
+      lastName:
+        type: "string"
+      email:
+        type: "string"
+      password:
+        type: "string"
+      phone:
+        type: "string"
+      userStatus:
+        type: "integer"
+        format: "int32"
+        description: "User Status"
+    xml:
+      name: "User"
+externalDocs:
+  description: "Find out more about Swagger"
+  url: "http://swagger.io"


### PR DESCRIPTION
This PR aims to provide a broader case coverage on the supported use cases of the generator. 

It implements unit tests against a more complete specification and checks if the generator handles new cases correctly. The spec used is the Swagger's example spec Petstore. 

By implementing such tests, it emerged the generator didn't handle `default` responses. I added such behaviour with the following principle:

`The successType is the 2xx response if present, or the default if present`