### PR TITLE
[#169915207] handle multiple 2xx types in response type generation

### DIFF
--- a/e2e/api.yaml
+++ b/e2e/api.yaml
@@ -33,6 +33,23 @@ paths:
           description: "Will send `Authenticated`"
         "403":
           description: "You do not have necessary permissions for the resource"
+  /test-multiple-success:
+    get:
+      operationId: "testMultipleSuccess"
+      responses:
+        "200":
+          description: "Will return a Message"
+          schema:
+            $ref: "#/definitions/Message"
+        "202":
+          description: "Will return just accepted"
+        "403":
+          description: "You do not have necessary permissions for the resource"
+          schema:
+            $ref: "#/definitions/OneOfTest"
+        "404":
+          description: "Not found"
+
   /test-file-upload:
     post:
       operationId: "testFileUpload"

--- a/e2e/be.yaml
+++ b/e2e/be.yaml
@@ -120,7 +120,66 @@ paths:
             $ref: "#/definitions/ProblemJson"
       parameters:
         - $ref: "#/parameters/PaginationRequest"
+  "/email-validation-process":
+    x-swagger-router-controller: ProfileController
+    post:
+      operationId: startEmailValidationProcess
+      summary: Start the Email Validation Process
+      description: |-
+        Start the email validation process that create the validation token
+        and send the validation email
+      responses:
+        "202":
+          description: Accepted
+        "400":
+          description: Bad request
+          schema:
+            $ref: "#/definitions/ProblemJson"
+        "401":
+          description: Bearer token null or expired.
+        "404":
+          description: Profile not found
+          schema:
+            $ref: "#/definitions/ProblemJson"
+        "429":
+          description: Too many requests
+          schema:
+            $ref: "#/definitions/ProblemJson"
+        "500":
+          description: There was an error in retrieving the user profile.
+          schema:
+            $ref: "#/definitions/ProblemJson"
+  "/user-metadata":
+    x-swagger-router-controller: userMetadataController
+    get:
+      operationId: getUserMetadata
+      summary: Get user's metadata
+      description: Returns metadata for the current authenticated user.
+      responses:
+        "200":
+          description: Found.
+          schema:
+            $ref: "#/definitions/UserMetadata"
+        "204":
+          description: No Content.
+        "401":
+          description: Bearer token null or expired.
+        "500":
+          description: There was an error in retrieving the user metadata.
+          schema:
+            $ref: "#/definitions/ProblemJson"
 definitions:
+  UserMetadata:
+    type: object
+    title: User Metadata information
+    properties:
+      version:
+        type: number
+      metadata:
+        type: string
+    required:
+      - version
+      - metadata
   DepartmentName:
     type: string
     description: |-

--- a/e2e/src/__tests__/be/definitions.test.ts
+++ b/e2e/src/__tests__/be/definitions.test.ts
@@ -49,4 +49,32 @@ describeSuite("Decoders generated from BE API spec defintions", () => {
       expect(result).toEqual(expectedRight);
     });
   });
+
+  describe("PaginatedServiceTupleCollection definition", () => {
+    it("should expose PaginatedServiceTupleCollection decoder", async () => {
+      const { PaginatedServiceTupleCollection } = await loadModule(
+        "PaginatedServiceTupleCollection"
+      );
+      expect(PaginatedServiceTupleCollection).toBeDefined();
+    });
+
+    const paginatedServices = {
+      items: [{ service_id: "foo123", version: 789 }],
+      next: "http://example.com/next",
+      page_size: 1
+    };
+
+    it.each`
+      title                                           | example              | expectedRight
+      ${"should fail decoding empty"}                 | ${undefined}         | ${false}
+      ${"should fail decoding non-object"}            | ${"INVALID"}         | ${false}
+      ${"should decode valid paginated service list"} | ${paginatedServices} | ${true}
+    `("$title", async ({ example, expectedRight }) => {
+      const { PaginatedServiceTupleCollection } = await loadModule(
+        "PaginatedServiceTupleCollection"
+      );
+      const result = PaginatedServiceTupleCollection.decode(example).isRight();
+      expect(result).toEqual(expectedRight);
+    });
+  });
 });

--- a/e2e/src/__tests__/be/request-types.test.ts
+++ b/e2e/src/__tests__/be/request-types.test.ts
@@ -1,10 +1,11 @@
 import * as t from "io-ts";
 import config from "../../config";
+import * as requestTypes from "../../generated/be/requestTypes";
 
 const mockResponse = (status: number, body?: any, headers?: any) => ({
   status,
   json: async () => body,
-  headers
+  headers,
 });
 
 const { generatedFilesDir, isSpecEnabled } = config.specs.be;
@@ -13,15 +14,147 @@ const { generatedFilesDir, isSpecEnabled } = config.specs.be;
 const describeSuite = isSpecEnabled ? describe : describe.skip;
 
 describeSuite("Request types generated from BE API spec", () => {
-  const loadModule = () =>
-    import(`${generatedFilesDir}/requestTypes.ts`).then(mod => {
-      if (!mod) {
-        fail(`Cannot load module ${generatedFilesDir}/requestTypes.ts`);
-      }
-      return mod;
+  describe("getServicesByRecipientDecoder", () => {
+    it("should be a function", async () => {
+      const { getServicesByRecipientDecoder } = requestTypes;
+      expect(getServicesByRecipientDecoder).toBeDefined();
+      expect(getServicesByRecipientDecoder).toEqual(expect.any(Function));
     });
 
-  it("should just pass", () => {
-    expect(1).toBe(1);
+    const paginatedServices = {
+      items: [{ service_id: "foo123", version: 789 }],
+      next: "http://example.com/next",
+      page_size: 1,
+    };
+
+    it.each`
+      title                                        | response                                  | expectedRight                                           | expectedLeft
+      ${"shoudln't decode scalar value/number"}    | ${200}                                    | ${undefined}                                            | ${undefined}
+      ${"shoudln't decode scalar value/string"}    | ${"any value"}                            | ${undefined}                                            | ${undefined}
+      ${"should decode 200 with valid body"}       | ${mockResponse(200, paginatedServices)}   | ${{ status: 200, value: paginatedServices }}            | ${undefined}
+      ${"should decode 200 with invalid body"}     | ${mockResponse(200, { invalid: "body" })} | ${undefined}                                            | ${expect.any(Object)}
+      ${"should decode 200 with empty body"}       | ${mockResponse(200 /*, undefined */)}     | ${undefined}                                            | ${expect.any(Object)}
+      ${"should decode 400 with any value/string"} | ${mockResponse(400, "any value")}         | ${undefined}                                            | ${expect.any(Object)}
+      ${"should decode 400 with any value/object"} | ${mockResponse(400, { foo: "bar" })}      | ${{ status: 400, value: { type: expect.any(String) } }} | ${undefined}
+      ${"shoudln't decode unhandled http code"}    | ${mockResponse(418, { foo: "bar" })}      | ${undefined}                                            | ${undefined}
+    `(
+      "$title",
+      async ({
+        response,
+        expectedRight,
+        expectedLeft,
+        cannotDecode = !expectedRight && !expectedLeft,
+      }) => {
+        const { getServicesByRecipientDecoder } = requestTypes;
+        const decoder = getServicesByRecipientDecoder();
+        const result = await decoder(response);
+        if (cannotDecode) {
+          expect(result).not.toBeDefined();
+        } else if (result) {
+          result.fold(
+            // in case the decoding gives a left, it checks the result against the expected value
+            (l: any) => expect(l).toEqual(expectedLeft),
+            // in case the decoding gives a right, it checks the result against the expected value
+            (r: any) => expect(r).toEqual(expectedRight)
+          );
+          expect(result.isRight()).toBe(typeof expectedRight !== "undefined");
+          expect(result.isLeft()).toBe(typeof expectedLeft !== "undefined");
+        } else {
+          fail("result should be defined");
+        }
+      }
+    );
+  });
+
+  describe("startEmailValidationProcessDecoder", () => {
+    it("should be a function", async () => {
+      const { startEmailValidationProcessDecoder } = requestTypes;
+      expect(startEmailValidationProcessDecoder).toBeDefined();
+      expect(startEmailValidationProcessDecoder).toEqual(expect.any(Function));
+    });
+
+    it.each`
+      title                                      | response                              | expectedRight                        | expectedLeft
+      ${"shoudln't decode scalar value/number"}  | ${200}                                | ${undefined}                         | ${undefined}
+      ${"shoudln't decode scalar value/string"}  | ${"any value"}                        | ${undefined}                         | ${undefined}
+      ${"should decode 202 with non-empty body"} | ${mockResponse(202, { foo: "bar" })}  | ${{ status: 202, value: undefined }} | ${undefined}
+      ${"should decode 202 with empty body"}     | ${mockResponse(202 /*, undefined */)} | ${{ status: 202, value: undefined }} | ${undefined}
+      ${"shoudln't decode unhandled http code"}  | ${mockResponse(418, { foo: "bar" })}  | ${undefined}                         | ${undefined}
+    `(
+      "$title",
+      async ({
+        response,
+        expectedRight,
+        expectedLeft,
+        cannotDecode = !expectedRight && !expectedLeft,
+      }) => {
+        const { startEmailValidationProcessDecoder } = requestTypes;
+        const decoder = startEmailValidationProcessDecoder();
+        const result = await decoder(response);
+        if (cannotDecode) {
+          expect(result).not.toBeDefined();
+        } else if (result) {
+          result.fold(
+            // in case the decoding gives a left, it checks the result against the expected value
+            (l: any) => expect(l).toEqual(expectedLeft),
+            // in case the decoding gives a right, it checks the result against the expected value
+            (r: any) => expect(r).toEqual(expectedRight)
+          );
+          expect(result.isRight()).toBe(typeof expectedRight !== "undefined");
+          expect(result.isLeft()).toBe(typeof expectedLeft !== "undefined");
+        } else {
+          fail("result should be defined");
+        }
+      }
+    );
+  });
+
+  describe("getUserMetadataDecoder", () => {
+    it("should be a function", async () => {
+      const { getUserMetadataDecoder } = requestTypes;
+      expect(getUserMetadataDecoder).toBeDefined();
+      expect(getUserMetadataDecoder).toEqual(expect.any(Function));
+    });
+
+    const validUserMetadata = { version: 123, metadata: "meta:data" };
+    const invalidUserMetadata = { invalid: "body" };
+
+    it.each`
+      title                                      | response                                  | expectedRight                                | expectedLeft
+      ${"shoudln't decode scalar value/number"}  | ${200}                                    | ${undefined}                                 | ${undefined}
+      ${"shoudln't decode scalar value/string"}  | ${"any value"}                            | ${undefined}                                 | ${undefined}
+      ${"should decode 204 with non-empty body"} | ${mockResponse(204, { foo: "bar" })}      | ${{ status: 204, value: undefined }}         | ${undefined}
+      ${"should decode 204 with empty body"}     | ${mockResponse(204 /*, undefined */)}     | ${{ status: 204, value: undefined }}         | ${undefined}
+      ${"should decode 200 with empty body"}     | ${mockResponse(200 /*, undefined */)}     | ${undefined}                                 | ${expect.any(Object)}
+      ${"should decode 200 with invalid body"}   | ${mockResponse(200, invalidUserMetadata)} | ${undefined}                                 | ${expect.any(Object)}
+      ${"should decode 200 with valid body"}     | ${mockResponse(200, validUserMetadata)}   | ${{ status: 200, value: validUserMetadata }} | ${undefined}
+      ${"shoudln't decode unhandled http code"}  | ${mockResponse(418, { foo: "bar" })}      | ${undefined}                                 | ${undefined}
+    `(
+      "$title",
+      async ({
+        response,
+        expectedRight,
+        expectedLeft,
+        cannotDecode = !expectedRight && !expectedLeft,
+      }) => {
+        const { getUserMetadataDecoder } = requestTypes;
+        const decoder = getUserMetadataDecoder();
+        const result = await decoder(response);
+        if (cannotDecode) {
+          expect(result).not.toBeDefined();
+        } else if (result) {
+          result.fold(
+            // in case the decoding gives a left, it checks the result against the expected value
+            (l: any) => expect(l).toEqual(expectedLeft),
+            // in case the decoding gives a right, it checks the result against the expected value
+            (r: any) => expect(r).toEqual(expectedRight)
+          );
+          expect(result.isRight()).toBe(typeof expectedRight !== "undefined");
+          expect(result.isLeft()).toBe(typeof expectedLeft !== "undefined");
+        } else {
+          fail("result should be defined");
+        }
+      }
+    );
   });
 });

--- a/e2e/src/__tests__/test-api/request-types.test.ts
+++ b/e2e/src/__tests__/test-api/request-types.test.ts
@@ -1,5 +1,6 @@
 import * as t from "io-ts";
 import config from "../../config";
+import * as requestTypes from "../../generated/testapi/requestTypes";
 
 // @ts-ignore because leaked-handles doesn't ship type defintions
 import * as leaked from "leaked-handles";
@@ -8,45 +9,31 @@ leaked.set({ debugSockets: true });
 const mockResponse = (status: number, body?: any, headers?: any) => ({
   status,
   json: async () => body,
-  headers
+  headers,
 });
 
-const { generatedFilesDir, isSpecEnabled } = config.specs.testapi;
+const { isSpecEnabled } = config.specs.testapi;
 
 // if there's no need for this suite in this particular run, just skip it
 const describeSuite = isSpecEnabled ? describe : describe.skip;
 
 describeSuite("Request types generated from Test API spec", () => {
-  const loadModule = () =>
-    import(`${generatedFilesDir}/requestTypes.ts`).then(mod => {
-      if (!mod) {
-        fail(`Cannot load module ${generatedFilesDir}/requestTypes.ts`);
-      }
-      return mod;
-    });
-
   describe("testAuthBearerDecoder", () => {
-    const BodyT = t.interface({
-      foo: t.string
-    });
-    type BodyT = t.TypeOf<typeof BodyT>;
-
     it("should be a function", async () => {
-      const { testAuthBearerDecoder } = await loadModule();
+      const { testAuthBearerDecoder } = requestTypes;
       expect(testAuthBearerDecoder).toBeDefined();
       expect(testAuthBearerDecoder).toEqual(expect.any(Function));
     });
 
     it.each`
-      title                                        | response                                 | expectedRight                             | expectedLeft
-      ${"shoudln't decode scalar value/number"}    | ${200}                                   | ${undefined}                              | ${undefined}
-      ${"shoudln't decode scalar value/string"}    | ${"any value"}                           | ${undefined}                              | ${undefined}
-      ${"should decode 200 with non-empty body"}   | ${mockResponse(200, { foo: "bar" })}     | ${{ status: 200, value: { foo: "bar" } }} | ${undefined}
-      ${"should decode 200 with invalid body"}     | ${mockResponse(200, { invalid: "bar" })} | ${undefined}                              | ${expect.any(Object)}
-      ${"should decode 200 with empty body"}       | ${mockResponse(200 /*, undefined */)}    | ${undefined}                              | ${expect.any(Object)}
-      ${"should decode 403 with any value/string"} | ${mockResponse(403, "any value")}        | ${{ status: 403 }}                        | ${undefined}
-      ${"should decode 403 with any value/object"} | ${mockResponse(403, { foo: "bar" })}     | ${{ status: 403 }}                        | ${undefined}
-      ${"shoudln't decode unhandled http code"}    | ${mockResponse(418, { foo: "bar" })}     | ${undefined}                              | ${undefined}
+      title                                        | response                              | expectedRight                        | expectedLeft
+      ${"shoudln't decode scalar value/number"}    | ${200}                                | ${undefined}                         | ${undefined}
+      ${"shoudln't decode scalar value/string"}    | ${"any value"}                        | ${undefined}                         | ${undefined}
+      ${"should decode 200 with non-empty body"}   | ${mockResponse(200, { foo: "bar" })}  | ${{ status: 200, value: undefined }} | ${undefined}
+      ${"should decode 200 with empty body"}       | ${mockResponse(200 /*, undefined */)} | ${{ status: 200, value: undefined }} | ${undefined}
+      ${"should decode 403 with any value/string"} | ${mockResponse(403, "any value")}     | ${{ status: 403, value: undefined }} | ${undefined}
+      ${"should decode 403 with any value/object"} | ${mockResponse(403, { foo: "bar" })}  | ${{ status: 403, value: undefined }} | ${undefined}
+      ${"shoudln't decode unhandled http code"}    | ${mockResponse(418, { foo: "bar" })}  | ${undefined}                         | ${undefined}
     `(
       "$title",
       async ({
@@ -55,12 +42,12 @@ describeSuite("Request types generated from Test API spec", () => {
         expectedLeft,
         cannotDecode = !expectedRight && !expectedLeft,
       }) => {
-        const { testAuthBearerDecoder } = await loadModule();
-        const decoder = testAuthBearerDecoder(BodyT);
+        const { testAuthBearerDecoder } = requestTypes;
+        const decoder = testAuthBearerDecoder();
         const result = await decoder(response);
         if (cannotDecode) {
           expect(result).not.toBeDefined();
-        } else {
+        } else if (result) {
           result.fold(
             // in case the decoding gives a left, it checks the result against the expected value
             (l: any) => expect(l).toEqual(expectedLeft),
@@ -69,6 +56,8 @@ describeSuite("Request types generated from Test API spec", () => {
           );
           expect(result.isRight()).toBe(typeof expectedRight !== "undefined");
           expect(result.isLeft()).toBe(typeof expectedLeft !== "undefined");
+        } else {
+          fail("result should be defined");
         }
       }
     );
@@ -76,7 +65,7 @@ describeSuite("Request types generated from Test API spec", () => {
 
   describe("testAuthBearerDefaultDecoder", () => {
     it("should be a function", async () => {
-      const { testAuthBearerDefaultDecoder } = await loadModule();
+      const { testAuthBearerDefaultDecoder } = requestTypes;
       expect(testAuthBearerDefaultDecoder).toBeDefined();
       expect(testAuthBearerDefaultDecoder).toEqual(expect.any(Function));
     });
@@ -85,7 +74,7 @@ describeSuite("Request types generated from Test API spec", () => {
       title                                        | response                              | expectedRight                        | expectedLeft
       ${"shoudln't decode scalar value/number"}    | ${200}                                | ${undefined}                         | ${undefined}
       ${"shoudln't decode scalar value/string"}    | ${"any value"}                        | ${undefined}                         | ${undefined}
-      ${"should decode 200 with non-empty body"}   | ${mockResponse(200, { foo: "bar" })}  | ${undefined}                         | ${expect.any(Object)}
+      ${"should decode 200 with non-empty body"}   | ${mockResponse(200, { foo: "bar" })}  | ${{ status: 200, value: undefined }} | ${undefined}
       ${"should decode 200 with empty body"}       | ${mockResponse(200 /*, undefined */)} | ${{ status: 200, value: undefined }} | ${undefined}
       ${"should decode 403 with any value/string"} | ${mockResponse(403, "any value")}     | ${{ status: 403 }}                   | ${undefined}
       ${"should decode 403 with any value/object"} | ${mockResponse(403, { foo: "bar" })}  | ${{ status: 403 }}                   | ${undefined}
@@ -98,12 +87,12 @@ describeSuite("Request types generated from Test API spec", () => {
         expectedLeft,
         cannotDecode = !expectedRight && !expectedLeft,
       }) => {
-        const { testAuthBearerDefaultDecoder } = await loadModule();
+        const { testAuthBearerDefaultDecoder } = requestTypes;
         const decoder = testAuthBearerDefaultDecoder();
         const result = await decoder(response);
         if (cannotDecode) {
           expect(result).not.toBeDefined();
-        } else {
+        } else if (result) {
           result.fold(
             // in case the decoding gives a left, it checks the result against the expected value
             (l: any) => expect(l).toEqual(expectedLeft),
@@ -112,70 +101,25 @@ describeSuite("Request types generated from Test API spec", () => {
           );
           expect(result.isRight()).toBe(typeof expectedRight !== "undefined");
           expect(result.isLeft()).toBe(typeof expectedLeft !== "undefined");
+        } else {
+          fail("result should be defined");
         }
       }
     );
   });
 
   describe("testFileUploadDecoder", () => {
-    const BodyT = t.interface({
-      foo: t.string
-    });
-    type BodyT = t.TypeOf<typeof BodyT>;
-
     it("should be a function", async () => {
-      const { testFileUploadDecoder } = await loadModule();
+      const { testFileUploadDecoder } = requestTypes;
       expect(testFileUploadDecoder).toBeDefined();
       expect(testFileUploadDecoder).toEqual(expect.any(Function));
-    });
-
-    it.each`
-      title                                      | response                                 | expectedRight                             | expectedLeft
-      ${"shoudln't decode scalar value/number"}  | ${200}                                   | ${undefined}                              | ${undefined}
-      ${"shoudln't decode scalar value/string"}  | ${"any value"}                           | ${undefined}                              | ${undefined}
-      ${"should decode 200 with non-empty body"} | ${mockResponse(200, { foo: "bar" })}     | ${{ status: 200, value: { foo: "bar" } }} | ${undefined}
-      ${"should decode 200 with invalid body"}   | ${mockResponse(200, { invalid: "bar" })} | ${undefined}                              | ${expect.any(Object)}
-      ${"should decode 200 with empty body"}     | ${mockResponse(200 /*, undefined */)}    | ${undefined}                              | ${expect.any(Object)}
-      ${"shoudln't decode unhandled http code"}  | ${mockResponse(418, { foo: "bar" })}     | ${undefined}                              | ${undefined}
-    `(
-      "$title",
-      async ({
-        response,
-        expectedRight,
-        expectedLeft,
-        cannotDecode = !expectedRight && !expectedLeft,
-      }) => {
-        const { testFileUploadDecoder } = await loadModule();
-        const decoder = testFileUploadDecoder(BodyT);
-        const result = await decoder(response);
-        if (cannotDecode) {
-          expect(result).not.toBeDefined();
-        } else {
-          result.fold(
-            // in case the decoding gives a left, it checks the result against the expected value
-            (l: any) => expect(l).toEqual(expectedLeft),
-            // in case the decoding gives a right, it checks the result against the expected value
-            (r: any) => expect(r).toEqual(expectedRight)
-          );
-          expect(result.isRight()).toBe(typeof expectedRight !== "undefined");
-          expect(result.isLeft()).toBe(typeof expectedLeft !== "undefined");
-        }
-      }
-    );
-  });
-
-  describe("testFileUploadDefaultDecoder", () => {
-    it("should be a function", async () => {
-      const { testFileUploadDefaultDecoder } = await loadModule();
-      expect(testFileUploadDefaultDecoder).toBeDefined();
-      expect(testFileUploadDefaultDecoder).toEqual(expect.any(Function));
     });
 
     it.each`
       title                                      | response                              | expectedRight                        | expectedLeft
       ${"shoudln't decode scalar value/number"}  | ${200}                                | ${undefined}                         | ${undefined}
       ${"shoudln't decode scalar value/string"}  | ${"any value"}                        | ${undefined}                         | ${undefined}
-      ${"should decode 200 with non-empty body"} | ${mockResponse(200, { foo: "bar" })}  | ${undefined}                         | ${expect.any(Object)}
+      ${"should decode 200 with non-empty body"} | ${mockResponse(200, { foo: "bar" })}  | ${{ status: 200, value: undefined }} | ${undefined}
       ${"should decode 200 with empty body"}     | ${mockResponse(200 /*, undefined */)} | ${{ status: 200, value: undefined }} | ${undefined}
       ${"shoudln't decode unhandled http code"}  | ${mockResponse(418, { foo: "bar" })}  | ${undefined}                         | ${undefined}
     `(
@@ -186,12 +130,12 @@ describeSuite("Request types generated from Test API spec", () => {
         expectedLeft,
         cannotDecode = !expectedRight && !expectedLeft,
       }) => {
-        const { testFileUploadDefaultDecoder } = await loadModule();
-        const decoder = testFileUploadDefaultDecoder();
+        const { testFileUploadDecoder } = requestTypes;
+        const decoder = testFileUploadDecoder();
         const result = await decoder(response);
         if (cannotDecode) {
           expect(result).not.toBeDefined();
-        } else {
+        } else if (result) {
           result.fold(
             // in case the decoding gives a left, it checks the result against the expected value
             (l: any) => expect(l).toEqual(expectedLeft),
@@ -200,6 +144,51 @@ describeSuite("Request types generated from Test API spec", () => {
           );
           expect(result.isRight()).toBe(typeof expectedRight !== "undefined");
           expect(result.isLeft()).toBe(typeof expectedLeft !== "undefined");
+        } else {
+          fail("result should be defined");
+        }
+      }
+    );
+  });
+
+  describe("testFileUploadDefaultDecoder", () => {
+    it("should be a function", async () => {
+      const { testFileUploadDefaultDecoder } = requestTypes;
+      expect(testFileUploadDefaultDecoder).toBeDefined();
+      expect(testFileUploadDefaultDecoder).toEqual(expect.any(Function));
+    });
+
+    it.each`
+      title                                      | response                              | expectedRight                        | expectedLeft
+      ${"shoudln't decode scalar value/number"}  | ${200}                                | ${undefined}                         | ${undefined}
+      ${"shoudln't decode scalar value/string"}  | ${"any value"}                        | ${undefined}                         | ${undefined}
+      ${"should decode 200 with non-empty body"} | ${mockResponse(200, { foo: "bar" })}  | ${{ status: 200, value: undefined }} | ${undefined}
+      ${"should decode 200 with empty body"}     | ${mockResponse(200 /*, undefined */)} | ${{ status: 200, value: undefined }} | ${undefined}
+      ${"shoudln't decode unhandled http code"}  | ${mockResponse(418, { foo: "bar" })}  | ${undefined}                         | ${undefined}
+    `(
+      "$title",
+      async ({
+        response,
+        expectedRight,
+        expectedLeft,
+        cannotDecode = !expectedRight && !expectedLeft,
+      }) => {
+        const { testFileUploadDefaultDecoder } = requestTypes;
+        const decoder = testFileUploadDefaultDecoder();
+        const result = await decoder(response);
+        if (cannotDecode) {
+          expect(result).not.toBeDefined();
+        } else if (result) {
+          result.fold(
+            // in case the decoding gives a left, it checks the result against the expected value
+            (l: any) => expect(l).toEqual(expectedLeft),
+            // in case the decoding gives a right, it checks the result against the expected value
+            (r: any) => expect(r).toEqual(expectedRight)
+          );
+          expect(result.isRight()).toBe(typeof expectedRight !== "undefined");
+          expect(result.isLeft()).toBe(typeof expectedLeft !== "undefined");
+        } else {
+          fail("result should be defined");
         }
       }
     );

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "version": "npm run build",
     "postversion": "git push && git push --tags",
     "e2e": "yarn build && cd ./e2e && yarn install --frozen-lockfile && yarn start",
+    "pretest": "jest --clearCache",
     "test": "jest src/*",
     "lint": "tslint --project .",
     "test:coverage": "jest --coverage"

--- a/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
+++ b/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
@@ -557,6 +557,8 @@ export function Client(
   > = {
     method: \\"get\\",
 
+    headers: () => ({}),
+
     response_decoder: testMultipleSuccessDefaultDecoder(),
     url: ({}) => \`\${basePath}/test-multiple-success\`,
 

--- a/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
+++ b/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
@@ -172,11 +172,39 @@ exports[`gen-api-models should generate the operator definition 1`] = `
     // Request type definition
     export type TestAuthBearerT = r.IGetApiRequestType<{readonly bearerToken: string,readonly qo?: string,readonly qr: string,readonly cursor?: string}, \\"Authorization\\", never, r.IResponseType<200, undefined>|r.IResponseType<403, undefined>>;
   
-        // Decodes the success response with a custom success type
-        export function testAuthBearerDecoder<A, O>(type: t.Type<A, O>) { return r.composeResponseDecoders(r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type), r.constantResponseDecoder<undefined, 403>(403, undefined)); }
+      
+    export const testAuthBearerDefaultResponses = {
+      200: t.undefined, 403: t.undefined
+    };
+  
+      
+    export type TestAuthBearerResponsesT = {
+      200: t.UndefinedC, 403: t.UndefinedC
+    };
+  
+      export function testAuthBearerDecoder(): r.ResponseDecoder<
+    r.IResponseType<200, undefined, never>|r.IResponseType<403, undefined, never>
+  >;;
+      export function testAuthBearerDecoder(overrideTypes: t.UndefinedC): r.ResponseDecoder<
+    r.IResponseType<200, undefined, never>|r.IResponseType<403, undefined, never>
+  >;;
+      export function testAuthBearerDecoder(overrideTypes: Partial<TestAuthBearerResponsesT>): r.ResponseDecoder<
+    r.IResponseType<200, undefined, never>|r.IResponseType<403, undefined, never>
+  >;;
+      export function testAuthBearerDecoder(overrideTypes: Partial<TestAuthBearerResponsesT> | t.UndefinedC = {}) {
+        const isDecoder = (d: any): d is t.UndefinedC =>
+          typeof d[\\"_A\\"] !== \\"undefined\\";
 
-        // Decodes the success response with the type defined in the specs
-        export const testAuthBearerDefaultDecoder = () => testAuthBearerDecoder(t.undefined);"
+        const type = {
+          ...(testAuthBearerDefaultResponses as unknown as TestAuthBearerResponsesT),
+          ...(isDecoder(overrideTypes) ? { 200: overrideTypes } : overrideTypes)
+        };
+
+        return r.composeResponseDecoders(r.constantResponseDecoder<undefined, 200>(200, undefined), r.constantResponseDecoder<undefined, 403>(403, undefined))
+      }
+
+      // Decodes the success response with the type defined in the specs
+      export const testAuthBearerDefaultDecoder = () => testAuthBearerDecoder();"
 `;
 
 exports[`gen-api-models should handle CustomStringFormats: custom-string-format 1`] = `
@@ -485,6 +513,8 @@ import {
 import {
   TestAuthBearerT,
   testAuthBearerDefaultDecoder,
+  TestMultipleSuccessT,
+  testMultipleSuccessDefaultDecoder,
   TestFileUploadT,
   testFileUploadDefaultDecoder
 } from \\"./requestTypes\\";
@@ -496,6 +526,7 @@ export function Client(
   basePath: string = \\"/api/v1\\"
 ): {
   readonly testAuthBearer: TypeofApiCall<typeof testAuthBearerT>;
+  readonly testMultipleSuccess: TypeofApiCall<typeof testMultipleSuccessT>;
   readonly testFileUpload: TypeofApiCall<typeof testFileUploadT>;
 } {
   const options = {
@@ -520,6 +551,22 @@ export function Client(
   };
   const testAuthBearer = createFetchRequestForApi(testAuthBearerT, options);
 
+  const testMultipleSuccessT: ReplaceRequestParams<
+    TestMultipleSuccessT,
+    RequestParams<TestMultipleSuccessT>
+  > = {
+    method: \\"get\\",
+
+    response_decoder: testMultipleSuccessDefaultDecoder(),
+    url: ({}) => \`\${basePath}/test-multiple-success\`,
+
+    query: () => ({})
+  };
+  const testMultipleSuccess = createFetchRequestForApi(
+    testMultipleSuccessT,
+    options
+  );
+
   const testFileUploadT: ReplaceRequestParams<
     TestFileUploadT,
     RequestParams<TestFileUploadT>
@@ -539,6 +586,7 @@ export function Client(
 
   return {
     testAuthBearer,
+    testMultipleSuccess,
     testFileUpload
   };
 }
@@ -585,9 +633,81 @@ exports[`gen-api-models should support file uploads 1`] = `
     // Request type definition
     export type TestFileUploadT = r.IPostApiRequestType<{readonly file: { uri: string, name: string, type: string }}, \\"Content-Type\\", never, r.IResponseType<200, undefined>>;
   
-        // Decodes the success response with a custom success type
-        export function testFileUploadDecoder<A, O>(type: t.Type<A, O>) { return r.ioResponseDecoder<200, (typeof type)[\\"_A\\"], (typeof type)[\\"_O\\"]>(200, type); }
+      
+    export const testFileUploadDefaultResponses = {
+      200: t.undefined
+    };
+  
+      
+    export type TestFileUploadResponsesT = {
+      200: t.UndefinedC
+    };
+  
+      export function testFileUploadDecoder(): r.ResponseDecoder<
+    r.IResponseType<200, undefined, never>
+  >;;
+      export function testFileUploadDecoder(overrideTypes: t.UndefinedC): r.ResponseDecoder<
+    r.IResponseType<200, undefined, never>
+  >;;
+      export function testFileUploadDecoder(overrideTypes: Partial<TestFileUploadResponsesT>): r.ResponseDecoder<
+    r.IResponseType<200, undefined, never>
+  >;;
+      export function testFileUploadDecoder(overrideTypes: Partial<TestFileUploadResponsesT> | t.UndefinedC = {}) {
+        const isDecoder = (d: any): d is t.UndefinedC =>
+          typeof d[\\"_A\\"] !== \\"undefined\\";
 
-        // Decodes the success response with the type defined in the specs
-        export const testFileUploadDefaultDecoder = () => testFileUploadDecoder(t.undefined);"
+        const type = {
+          ...(testFileUploadDefaultResponses as unknown as TestFileUploadResponsesT),
+          ...(isDecoder(overrideTypes) ? { 200: overrideTypes } : overrideTypes)
+        };
+
+        return r.constantResponseDecoder<undefined, 200>(200, undefined)
+      }
+
+      // Decodes the success response with the type defined in the specs
+      export const testFileUploadDefaultDecoder = () => testFileUploadDecoder();"
+`;
+
+exports[`gen-api-models should support multiple success cases 1`] = `
+"
+    /****************************************************************
+     * testMultipleSuccess
+     */
+
+    // Request type definition
+    export type TestMultipleSuccessT = r.IGetApiRequestType<{}, never, never, r.IResponseType<200, Message>|r.IResponseType<202, undefined>|r.IResponseType<403, OneOfTest>|r.IResponseType<404, undefined>>;
+  
+      
+    export const testMultipleSuccessDefaultResponses = {
+      200: Message, 202: t.undefined, 403: OneOfTest, 404: t.undefined
+    };
+  
+      
+    export type TestMultipleSuccessResponsesT<A0 extends Message, C0 extends Message, A2 extends OneOfTest, C2 extends OneOfTest> = {
+      200: t.Type<A0, C0>, 202: t.UndefinedC, 403: t.Type<A2, C2>, 404: t.UndefinedC
+    };
+  
+      export function testMultipleSuccessDecoder<A0 extends Message, C0 extends Message, A2 extends OneOfTest, C2 extends OneOfTest>(): r.ResponseDecoder<
+    r.IResponseType<200, A0, never>|r.IResponseType<202, undefined, never>|r.IResponseType<403, A2, never>|r.IResponseType<404, undefined, never>
+  >;;
+      export function testMultipleSuccessDecoder<A0 extends Message, C0 extends Message, A2 extends OneOfTest, C2 extends OneOfTest>(overrideTypes: t.Type<A0, C0>): r.ResponseDecoder<
+    r.IResponseType<200, A0, never>|r.IResponseType<202, undefined, never>|r.IResponseType<403, A2, never>|r.IResponseType<404, undefined, never>
+  >;;
+      export function testMultipleSuccessDecoder<A0 extends Message, C0 extends Message, A2 extends OneOfTest, C2 extends OneOfTest>(overrideTypes: Partial<TestMultipleSuccessResponsesT<A0, C0, A2, C2>>): r.ResponseDecoder<
+    r.IResponseType<200, A0, never>|r.IResponseType<202, undefined, never>|r.IResponseType<403, A2, never>|r.IResponseType<404, undefined, never>
+  >;;
+      export function testMultipleSuccessDecoder<A0 extends Message, C0 extends Message, A2 extends OneOfTest, C2 extends OneOfTest>(overrideTypes: Partial<TestMultipleSuccessResponsesT<A0, C0, A2, C2>> | t.Type<A0, C0> = {}) {
+        const isDecoder = (d: any): d is t.Type<A0, C0> =>
+          typeof d[\\"_A\\"] !== \\"undefined\\";
+
+        const type = {
+          ...(testMultipleSuccessDefaultResponses as unknown as TestMultipleSuccessResponsesT<A0, C0, A2, C2>),
+          ...(isDecoder(overrideTypes) ? { 200: overrideTypes } : overrideTypes)
+        };
+
+        return r.composeResponseDecoders(r.composeResponseDecoders(r.composeResponseDecoders(r.ioResponseDecoder<200, (typeof type[200])[\\"_A\\"], (typeof type[200])[\\"_O\\"]>(200, type[200]), r.constantResponseDecoder<undefined, 202>(202, undefined)), r.ioResponseDecoder<403, (typeof type[403])[\\"_A\\"], (typeof type[403])[\\"_O\\"]>(403, type[403])), r.constantResponseDecoder<undefined, 404>(404, undefined))
+      }
+
+      // Decodes the success response with the type defined in the specs
+      export const testMultipleSuccessDefaultDecoder = () => testMultipleSuccessDecoder();"
 `;

--- a/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
+++ b/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
@@ -178,29 +178,31 @@ exports[`gen-api-models should generate the operator definition 1`] = `
     };
   
       
-    export type TestAuthBearerResponsesT = {
-      200: t.UndefinedC, 403: t.UndefinedC
+    export type TestAuthBearerResponsesT<A0 = undefined, C0 = undefined, A1 = undefined, C1 = undefined> = {
+      200: t.Type<A0, C0>, 403: t.Type<A1, C1>
     };
   
-      export function testAuthBearerDecoder(): r.ResponseDecoder<
-    r.IResponseType<200, undefined, never>|r.IResponseType<403, undefined, never>
-  >;;
-      export function testAuthBearerDecoder(overrideTypes: t.UndefinedC): r.ResponseDecoder<
-    r.IResponseType<200, undefined, never>|r.IResponseType<403, undefined, never>
-  >;;
-      export function testAuthBearerDecoder(overrideTypes: Partial<TestAuthBearerResponsesT>): r.ResponseDecoder<
-    r.IResponseType<200, undefined, never>|r.IResponseType<403, undefined, never>
-  >;;
-      export function testAuthBearerDecoder(overrideTypes: Partial<TestAuthBearerResponsesT> | t.UndefinedC = {}) {
-        const isDecoder = (d: any): d is t.UndefinedC =>
+      export function testAuthBearerDecoder<A0 = undefined, C0 = undefined, A1 = undefined, C1 = undefined>(overrideTypes: Partial<TestAuthBearerResponsesT<A0, C0, A1, C1>> | t.Type<A0, C0> | undefined = {}): r.ResponseDecoder<
+    r.IResponseType<200, A0, never>|r.IResponseType<403, A1, never>
+  > {
+        const isDecoder = (d: any): d is t.Type<A0, C0> =>
           typeof d[\\"_A\\"] !== \\"undefined\\";
 
         const type = {
-          ...(testAuthBearerDefaultResponses as unknown as TestAuthBearerResponsesT),
+          ...(testAuthBearerDefaultResponses as unknown as TestAuthBearerResponsesT<A0, C0, A1, C1>),
           ...(isDecoder(overrideTypes) ? { 200: overrideTypes } : overrideTypes)
         };
 
-        return r.composeResponseDecoders(r.constantResponseDecoder<undefined, 200>(200, undefined), r.constantResponseDecoder<undefined, 403>(403, undefined))
+        
+    const d200 = (type[200].name === \\"undefined\\" 
+        ? r.constantResponseDecoder<undefined, 200>(200, undefined) 
+        : r.ioResponseDecoder<200, (typeof type[200])[\\"_A\\"], (typeof type[200])[\\"_O\\"]>(200, type[200])) as r.ResponseDecoder<r.IResponseType<200, A0, never>>;
+  
+    const d403 = (type[403].name === \\"undefined\\" 
+        ? r.constantResponseDecoder<undefined, 403>(403, undefined) 
+        : r.ioResponseDecoder<403, (typeof type[403])[\\"_A\\"], (typeof type[403])[\\"_O\\"]>(403, type[403])) as r.ResponseDecoder<r.IResponseType<403, A1, never>>;
+  
+        return r.composeResponseDecoders(d200, d403)
       }
 
       // Decodes the success response with the type defined in the specs
@@ -641,29 +643,27 @@ exports[`gen-api-models should support file uploads 1`] = `
     };
   
       
-    export type TestFileUploadResponsesT = {
-      200: t.UndefinedC
+    export type TestFileUploadResponsesT<A0 = undefined, C0 = undefined> = {
+      200: t.Type<A0, C0>
     };
   
-      export function testFileUploadDecoder(): r.ResponseDecoder<
-    r.IResponseType<200, undefined, never>
-  >;;
-      export function testFileUploadDecoder(overrideTypes: t.UndefinedC): r.ResponseDecoder<
-    r.IResponseType<200, undefined, never>
-  >;;
-      export function testFileUploadDecoder(overrideTypes: Partial<TestFileUploadResponsesT>): r.ResponseDecoder<
-    r.IResponseType<200, undefined, never>
-  >;;
-      export function testFileUploadDecoder(overrideTypes: Partial<TestFileUploadResponsesT> | t.UndefinedC = {}) {
-        const isDecoder = (d: any): d is t.UndefinedC =>
+      export function testFileUploadDecoder<A0 = undefined, C0 = undefined>(overrideTypes: Partial<TestFileUploadResponsesT<A0, C0>> | t.Type<A0, C0> | undefined = {}): r.ResponseDecoder<
+    r.IResponseType<200, A0, never>
+  > {
+        const isDecoder = (d: any): d is t.Type<A0, C0> =>
           typeof d[\\"_A\\"] !== \\"undefined\\";
 
         const type = {
-          ...(testFileUploadDefaultResponses as unknown as TestFileUploadResponsesT),
+          ...(testFileUploadDefaultResponses as unknown as TestFileUploadResponsesT<A0, C0>),
           ...(isDecoder(overrideTypes) ? { 200: overrideTypes } : overrideTypes)
         };
 
-        return r.constantResponseDecoder<undefined, 200>(200, undefined)
+        
+    const d200 = (type[200].name === \\"undefined\\" 
+        ? r.constantResponseDecoder<undefined, 200>(200, undefined) 
+        : r.ioResponseDecoder<200, (typeof type[200])[\\"_A\\"], (typeof type[200])[\\"_O\\"]>(200, type[200])) as r.ResponseDecoder<r.IResponseType<200, A0, never>>;
+  
+        return d200
       }
 
       // Decodes the success response with the type defined in the specs
@@ -685,29 +685,39 @@ exports[`gen-api-models should support multiple success cases 1`] = `
     };
   
       
-    export type TestMultipleSuccessResponsesT<A0 extends Message, C0 extends Message, A2 extends OneOfTest, C2 extends OneOfTest> = {
-      200: t.Type<A0, C0>, 202: t.UndefinedC, 403: t.Type<A2, C2>, 404: t.UndefinedC
+    export type TestMultipleSuccessResponsesT<A0 = Message, C0 = Message, A1 = undefined, C1 = undefined, A2 = OneOfTest, C2 = OneOfTest, A3 = undefined, C3 = undefined> = {
+      200: t.Type<A0, C0>, 202: t.Type<A1, C1>, 403: t.Type<A2, C2>, 404: t.Type<A3, C3>
     };
   
-      export function testMultipleSuccessDecoder<A0 extends Message, C0 extends Message, A2 extends OneOfTest, C2 extends OneOfTest>(): r.ResponseDecoder<
-    r.IResponseType<200, A0, never>|r.IResponseType<202, undefined, never>|r.IResponseType<403, A2, never>|r.IResponseType<404, undefined, never>
-  >;;
-      export function testMultipleSuccessDecoder<A0 extends Message, C0 extends Message, A2 extends OneOfTest, C2 extends OneOfTest>(overrideTypes: t.Type<A0, C0>): r.ResponseDecoder<
-    r.IResponseType<200, A0, never>|r.IResponseType<202, undefined, never>|r.IResponseType<403, A2, never>|r.IResponseType<404, undefined, never>
-  >;;
-      export function testMultipleSuccessDecoder<A0 extends Message, C0 extends Message, A2 extends OneOfTest, C2 extends OneOfTest>(overrideTypes: Partial<TestMultipleSuccessResponsesT<A0, C0, A2, C2>>): r.ResponseDecoder<
-    r.IResponseType<200, A0, never>|r.IResponseType<202, undefined, never>|r.IResponseType<403, A2, never>|r.IResponseType<404, undefined, never>
-  >;;
-      export function testMultipleSuccessDecoder<A0 extends Message, C0 extends Message, A2 extends OneOfTest, C2 extends OneOfTest>(overrideTypes: Partial<TestMultipleSuccessResponsesT<A0, C0, A2, C2>> | t.Type<A0, C0> = {}) {
+      export function testMultipleSuccessDecoder<A0 = Message, C0 = Message, A1 = undefined, C1 = undefined, A2 = OneOfTest, C2 = OneOfTest, A3 = undefined, C3 = undefined>(overrideTypes: Partial<TestMultipleSuccessResponsesT<A0, C0, A1, C1, A2, C2, A3, C3>> | t.Type<A0, C0> | undefined = {}): r.ResponseDecoder<
+    r.IResponseType<200, A0, never>|r.IResponseType<202, A1, never>|r.IResponseType<403, A2, never>|r.IResponseType<404, A3, never>
+  > {
         const isDecoder = (d: any): d is t.Type<A0, C0> =>
           typeof d[\\"_A\\"] !== \\"undefined\\";
 
         const type = {
-          ...(testMultipleSuccessDefaultResponses as unknown as TestMultipleSuccessResponsesT<A0, C0, A2, C2>),
+          ...(testMultipleSuccessDefaultResponses as unknown as TestMultipleSuccessResponsesT<A0, C0, A1, C1, A2, C2, A3, C3>),
           ...(isDecoder(overrideTypes) ? { 200: overrideTypes } : overrideTypes)
         };
 
-        return r.composeResponseDecoders(r.composeResponseDecoders(r.composeResponseDecoders(r.ioResponseDecoder<200, (typeof type[200])[\\"_A\\"], (typeof type[200])[\\"_O\\"]>(200, type[200]), r.constantResponseDecoder<undefined, 202>(202, undefined)), r.ioResponseDecoder<403, (typeof type[403])[\\"_A\\"], (typeof type[403])[\\"_O\\"]>(403, type[403])), r.constantResponseDecoder<undefined, 404>(404, undefined))
+        
+    const d200 = (type[200].name === \\"undefined\\" 
+        ? r.constantResponseDecoder<undefined, 200>(200, undefined) 
+        : r.ioResponseDecoder<200, (typeof type[200])[\\"_A\\"], (typeof type[200])[\\"_O\\"]>(200, type[200])) as r.ResponseDecoder<r.IResponseType<200, A0, never>>;
+  
+    const d202 = (type[202].name === \\"undefined\\" 
+        ? r.constantResponseDecoder<undefined, 202>(202, undefined) 
+        : r.ioResponseDecoder<202, (typeof type[202])[\\"_A\\"], (typeof type[202])[\\"_O\\"]>(202, type[202])) as r.ResponseDecoder<r.IResponseType<202, A1, never>>;
+  
+    const d403 = (type[403].name === \\"undefined\\" 
+        ? r.constantResponseDecoder<undefined, 403>(403, undefined) 
+        : r.ioResponseDecoder<403, (typeof type[403])[\\"_A\\"], (typeof type[403])[\\"_O\\"]>(403, type[403])) as r.ResponseDecoder<r.IResponseType<403, A2, never>>;
+  
+    const d404 = (type[404].name === \\"undefined\\" 
+        ? r.constantResponseDecoder<undefined, 404>(404, undefined) 
+        : r.ioResponseDecoder<404, (typeof type[404])[\\"_A\\"], (typeof type[404])[\\"_O\\"]>(404, type[404])) as r.ResponseDecoder<r.IResponseType<404, A3, never>>;
+  
+        return r.composeResponseDecoders(r.composeResponseDecoders(r.composeResponseDecoders(d200, d202), d403), d404)
       }
 
       // Decodes the success response with the type defined in the specs

--- a/src/__tests__/api.yaml
+++ b/src/__tests__/api.yaml
@@ -33,6 +33,23 @@ paths:
           description: "Will send `Authenticated`"
         "403":
           description: "You do not have necessary permissions for the resource"
+  /test-multiple-success:
+    get:
+      operationId: "testMultipleSuccess"
+      responses:
+        "200":
+          description: "Will return a Message"
+          schema:
+            $ref: "#/definitions/Message"
+        "202":
+          description: "Will return just accepted"
+        "403":
+          description: "You do not have necessary permissions for the resource"
+          schema:
+            $ref: "#/definitions/OneOfTest"
+        "404":
+          description: "Not found"
+
   /test-file-upload:
     post:
       operationId: "testFileUpload"

--- a/src/__tests__/gen-api-models.test.ts
+++ b/src/__tests__/gen-api-models.test.ts
@@ -11,7 +11,7 @@ import {
   renderClientCode,
   renderDefinitionCode,
   renderOperation
-} from "../gen-api-models";
+} from "../gen-api-models/index";
 
 const env = initNunJucksEnvironment();
 

--- a/src/__tests__/gen-api-models.test.ts
+++ b/src/__tests__/gen-api-models.test.ts
@@ -10,7 +10,7 @@ import {
   parseOperation,
   renderClientCode,
   renderDefinitionCode,
-  renderOperation
+  renderOperation,
 } from "../gen-api-models/index";
 
 const env = initNunJucksEnvironment();
@@ -355,66 +355,21 @@ describe("gen-api-models", () => {
     }
   });
 
-  it("should parse operations", () => {
-    const expected = [
-      {
-        path: "/test-auth-bearer",
-        headers: ["Authorization"],
-        importedTypes: new Set(),
-        method: "get",
-        operationId: "testAuthBearer",
-        parameters: [
-          {
-            name: "bearerToken",
-            type: "string",
-            in: "header",
-            headerName: "Authorization",
-            tokenType: "apiKey"
-          },
-          {
-            name: "qo?",
-            type: "string",
-            in: "query"
-          },
-          {
-            name: "qr",
-            type: "string",
-            in: "query"
-          },
-          {
-            name: "cursor?",
-            type: "string",
-            in: "query"
-          }
-        ],
-        responses: [
-          { e1: "200", e2: "undefined" },
-          { e1: "403", e2: "undefined" }
-        ],
-        produces: "application/json"
-      },
-      {
-        path: "/test-file-upload",
-        headers: ["Content-Type"],
-        importedTypes: new Set(),
-        method: "post",
-        operationId: "testFileUpload",
-        parameters: [
-          {
-            name: "file",
-            type: "{ uri: string, name: string, type: string }",
-            in: "formData"
-          }
-        ],
-        responses: [{ e1: "200", e2: "undefined" }],
-        consumes: "multipart/form-data",
-        produces: "application/json"
-      }
-    ];
+  it("should support multiple success cases", async () => {
+    const operationInfo = parseOperation(
+      spec,
+      "/test-multiple-success",
+      [],
+      "undefined",
+      "undefined"
+    )("get");
 
-    const allOperations = parseAllOperations(spec, "undefined", "undefined");
-
-    expect(allOperations).toEqual(expected);
+    if (operationInfo) {
+      const code = renderOperation(operationInfo, true);
+      expect(code.e1).toMatchSnapshot();
+    } else {
+      fail("failed to parse operation");
+    }
   });
 
   it("should parse operations", () => {
@@ -431,29 +386,44 @@ describe("gen-api-models", () => {
             type: "string",
             in: "header",
             headerName: "Authorization",
-            tokenType: "apiKey"
+            tokenType: "apiKey",
           },
           {
             name: "qo?",
             type: "string",
-            in: "query"
+            in: "query",
           },
           {
             name: "qr",
             type: "string",
-            in: "query"
+            in: "query",
           },
           {
             name: "cursor?",
             type: "string",
-            in: "query"
-          }
+            in: "query",
+          },
         ],
         responses: [
           { e1: "200", e2: "undefined" },
-          { e1: "403", e2: "undefined" }
+          { e1: "403", e2: "undefined" },
         ],
-        produces: "application/json"
+        produces: "application/json",
+      },
+      {
+        path: "/test-multiple-success",
+        headers: [],
+        importedTypes: new Set(["Message", "OneOfTest"]),
+        method: "get",
+        operationId: "testMultipleSuccess",
+        parameters: [],
+        responses: [
+          { e1: "200", e2: "Message" },
+          { e1: "202", e2: "undefined" },
+          { e1: "403", e2: "OneOfTest" },
+          { e1: "404", e2: "undefined" },
+        ],
+        produces: "application/json",
       },
       {
         path: "/test-file-upload",
@@ -465,13 +435,13 @@ describe("gen-api-models", () => {
           {
             name: "file",
             type: "{ uri: string, name: string, type: string }",
-            in: "formData"
-          }
+            in: "formData",
+          },
         ],
         responses: [{ e1: "200", e2: "undefined" }],
         consumes: "multipart/form-data",
-        produces: "application/json"
-      }
+        produces: "application/json",
+      },
     ];
 
     const allOperations = parseAllOperations(spec, "undefined", "undefined");

--- a/templates/client.ts.njk
+++ b/templates/client.ts.njk
@@ -53,6 +53,8 @@ export function {{ moduleName }}(
     method: "{{ operation.method }}",
     {% if headerParams | length or operation.consumes %}
     headers: {{ macro.composedHeaderProducers(headerParams, operation.consumes) }},
+    {% else %}
+    headers: () => ({}),
     {% endif %}
     response_decoder: {{ macro.responseDecoderName(operation) }}(),
     url: ({ {{ pathParams | pick("name") | strip | join(', ') }} }) => `{{ macro.$("basePath") }}{{ macro.pathStringToTemplateString(operation.path) }}`,


### PR DESCRIPTION
This PR is inspired by #148 and tries to achieve the same result without losing backward compatibility.

This **is still a draft** because I'd like to write more tests and there are some open questions yet (see below).

### TL;DR
Generated response decoders now allow the user to provide a hash set of response decoders in the form _(httpCode, decoder)_. The set may be incomplete and will be filled by defaults. To ensure retrocompatibility, overloads are provided to allow the user to only pass the decoder for the success type (2xx).

### Problem
Response decoder generation cannot handle the following cases:
* an operation has more than a 2xx type
* an operation which 2xx type returns nothing

The main issue is that actual response decoders allow for only a httpcode-decoder to be overridden (and it's implicitly the first 2xx one).

### Solution 
Like in #148 response decoders allow for a hash set of decoders to be optionally passed, for example:
```typescript
{
  200: PaginatedServiceTupleCollection,
  401: t.undefined,
  429: t.undefined
}
```
The differences of this proposal are:
* partial sets are allowed (defaults are used to fulfill the object)
* a single decoder can be passed, and in this case is cosidered like `{ 200: MyFancyDecoder }` (where `200` is the first 2xx).
This is achieved by overloading the decoder function and my applying type-checking at runtime. 

An example of generated decoder would be:
```typescript
/****************************************************************
 * getServicesByRecipient
 */

// Request type definition
export type GetServicesByRecipientT = r.IGetApiRequestType<
  { readonly Bearer: string; readonly cursor?: string },
  "Authorization",
  never,
  | r.IResponseType<200, PaginatedServiceTupleCollection>
  | r.IResponseType<400, ProblemJson>
  | r.IResponseType<401, undefined>
  | r.IResponseType<429, ProblemJson>
  | r.IResponseType<500, ProblemJson>
>;

export const getServicesByRecipientDefaultResponses = {
  200: PaginatedServiceTupleCollection,
  400: ProblemJson,
  401: t.undefined,
  429: ProblemJson,
  500: ProblemJson
};

export type GetServicesByRecipientResponsesT<
  A0 extends PaginatedServiceTupleCollection, // <-- note the extend!
  C0 extends PaginatedServiceTupleCollection,
  A1 extends ProblemJson,
  C1 extends ProblemJson,
  A3 extends ProblemJson, // note there's no A2 and C2
  C3 extends ProblemJson,
  A4 extends ProblemJson,
  C4 extends ProblemJson
> = {
  200: t.Type<A0, C0>;
  400: t.Type<A1, C1>;
  401: t.UndefinedC;
  429: t.Type<A3, C3>;
  500: t.Type<A4, C4>;
};

// this allow for getServicesByRecipientDecoder(), as default
export function getServicesByRecipientDecoder<
  A0 extends PaginatedServiceTupleCollection,
  C0 extends PaginatedServiceTupleCollection,
  A1 extends ProblemJson,
  C1 extends ProblemJson,
  A3 extends ProblemJson,
  C3 extends ProblemJson,
  A4 extends ProblemJson,
  C4 extends ProblemJson
>(): r.ResponseDecoder<
  | r.IResponseType<200, A0, never>
  | r.IResponseType<400, A1, never>
  | r.IResponseType<401, undefined, never>
  | r.IResponseType<429, A3, never>
  | r.IResponseType<500, A4, never>
>;
// this allow getServicesByRecipientDecoder(MyFancyDecoder)  
// --> for retrocompatibility, it's just like getServicesByRecipientDecoder({ 200: MyFancyDecoder })  
export function getServicesByRecipientDecoder<
  A0 extends PaginatedServiceTupleCollection,
  C0 extends PaginatedServiceTupleCollection,
  A1 extends ProblemJson,
  C1 extends ProblemJson,
  A3 extends ProblemJson,
  C3 extends ProblemJson,
  A4 extends ProblemJson,
  C4 extends ProblemJson
>(
  overrideTypes: t.Type<A0, C0>
): r.ResponseDecoder<
  | r.IResponseType<200, A0, never>
  | r.IResponseType<400, A1, never>
  | r.IResponseType<401, undefined, never>
  | r.IResponseType<429, A3, never>
  | r.IResponseType<500, A4, never>
>;
// this is for full handling of response decoders
export function getServicesByRecipientDecoder<
  A0 extends PaginatedServiceTupleCollection,
  C0 extends PaginatedServiceTupleCollection,
  A1 extends ProblemJson,
  C1 extends ProblemJson,
  A3 extends ProblemJson,
  C3 extends ProblemJson,
  A4 extends ProblemJson,
  C4 extends ProblemJson
>(
  overrideTypes: Partial<
    GetServicesByRecipientResponsesT<A0, C0, A1, C1, A3, C3, A4, C4>
  >
): r.ResponseDecoder<
  | r.IResponseType<200, A0, never>
  | r.IResponseType<400, A1, never>
  | r.IResponseType<401, undefined, never>
  | r.IResponseType<429, A3, never>
  | r.IResponseType<500, A4, never>
>;
export function getServicesByRecipientDecoder<
  A0 extends PaginatedServiceTupleCollection,
  C0 extends PaginatedServiceTupleCollection,
  A1 extends ProblemJson,
  C1 extends ProblemJson,
  A3 extends ProblemJson,
  C3 extends ProblemJson,
  A4 extends ProblemJson,
  C4 extends ProblemJson
>(
  overrideTypes:
    | Partial<GetServicesByRecipientResponsesT<A0, C0, A1, C1, A3, C3, A4, C4>>
    | t.Type<A0, C0> = {}
) {
  // this typeguard is for switching between overloads
  // we need a better condition
  const isDecoder = (d: any): d is t.Type<A0, C0> =>
    typeof d["_A"] !== "undefined";

  // type contains the actual set of decoders to be used
  // it's composed at runtime
  const type = {
    ...((getServicesByRecipientDefaultResponses as unknown) as GetServicesByRecipientResponsesT<A0, C0, A1, C1, A3, C3, A4, C4>),
    ...(isDecoder(overrideTypes) ? { 200: overrideTypes } : overrideTypes)
  };

  return r.composeResponseDecoders(
    r.composeResponseDecoders(
      r.composeResponseDecoders(
        r.composeResponseDecoders(
          r.ioResponseDecoder<
            200,
            typeof type[200]["_A"],
            typeof type[200]["_O"]
          >(200, type[200]),
          r.ioResponseDecoder<
            400,
            typeof type[400]["_A"],
            typeof type[400]["_O"]
          >(400, type[400])
        ),
        r.constantResponseDecoder<undefined, 401>(401, undefined)
      ),
      r.ioResponseDecoder<429, typeof type[429]["_A"], typeof type[429]["_O"]>(
        429,
        type[429]
      )
    ),
    r.ioResponseDecoder<500, typeof type[500]["_A"], typeof type[500]["_O"]>(
      500,
      type[500]
    )
  );
}

// this is the default decoder
// --> it's actually useless due to the first overload, we keep it fo retro compatibility
export const getServicesByRecipientDefaultDecoder = () =>
  getServicesByRecipientDecoder();
```

### Expected usage 
```typescript
// a decoder for a type that extends the default
const MyValidDecoder = t.intersection({ foo: t.string }, PaginatedServiceTupleCollection)
// a decoder for a type that DOES NOT extend the default
const MyInvalidDecoder = t.interface({ foo: t.string })
// a decoder for a type that extends the default ProblemJson
const MyProblemJson = t.intersection({ foo: t.string }, ProblemJson)

// ok
getServicesByRecipientDecoder();
// ok
getServicesByRecipientDecoder({});
// ok
getServicesByRecipientDecoder({ 400: MyProblemJson, 200: MyValidDecoder});
// ok
getServicesByRecipientDecoder(MyValidDecoder);
// compile error: incompatible decoder
getServicesByRecipientDecoder(MyInvalidDecoder);
// compile error: incompatible decoder
getServicesByRecipientDecoder({ 200: MyInvalidDecoder });
```

### Questions
1. Is it good to only allow for compatible decoders (i.e. decoders that decodes overlapping types)? Have we got some counter example?
2. Should old signature, although supported, be marked as _deprecated_?



