### PR TITLE
[#172475199] fix client return type

### DIFF
--- a/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
+++ b/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
@@ -527,9 +527,18 @@ export function Client(
   fetchApi: typeof fetch,
   basePath: string = \\"/api/v1\\"
 ): {
-  readonly testAuthBearer: TypeofApiCall<typeof testAuthBearerT>;
-  readonly testMultipleSuccess: TypeofApiCall<typeof testMultipleSuccessT>;
-  readonly testFileUpload: TypeofApiCall<typeof testFileUploadT>;
+  readonly testAuthBearer: TypeofApiCall<
+    ReplaceRequestParams<TestAuthBearerT, RequestParams<TestAuthBearerT>>
+  >;
+  readonly testMultipleSuccess: TypeofApiCall<
+    ReplaceRequestParams<
+      TestMultipleSuccessT,
+      RequestParams<TestMultipleSuccessT>
+    >
+  >;
+  readonly testFileUpload: TypeofApiCall<
+    ReplaceRequestParams<TestFileUploadT, RequestParams<TestFileUploadT>>
+  >;
 } {
   const options = {
     baseUrl,

--- a/templates/client.ts.njk
+++ b/templates/client.ts.njk
@@ -34,7 +34,7 @@ export function {{ moduleName }}(
   fetchApi: typeof fetch,
   basePath: string = "{{ spec.basePath }}"
 ): {
-  {% for operation in operations %} readonly {{ operation.operationId }}: TypeofApiCall<typeof {{ operation.operationId }}T>;{% endfor %}
+  {% for operation in operations %} readonly {{ operation.operationId }}: TypeofApiCall<{{ macro.requestParamsType(operation) }}>;{% endfor %}
 } {
   const options = {
     baseUrl,
@@ -49,7 +49,7 @@ export function {{ moduleName }}(
   {% set pathParams = operation.parameters | paramIn("path") %}
   {% set formParams = operation.parameters | paramIn("formData") %}
 
-  const {{ operation.operationId }}T: ReplaceRequestParams<{{ macro.requestTypeName(operation) }},RequestParams<{{ macro.requestTypeName(operation) }}>> = {
+  const {{ operation.operationId }}T: {{ macro.requestParamsType(operation) }} = {
     method: "{{ operation.method }}",
     {% if headerParams | length or operation.consumes %}
     headers: {{ macro.composedHeaderProducers(headerParams, operation.consumes) }},

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -399,6 +399,12 @@
 {% endmacro -%}
 
 {##
+ # The composed request param type associated to an operation
+ # example: { operationId: "myOp", ...rest } -> ReplaceRequestParams<MyOp,RequestParams<MyOp>>
+ #}
+{% macro requestParamsType(operation) -%}ReplaceRequestParams<{{ requestTypeName(operation) }},RequestParams<{{ requestTypeName(operation) }}>>{% endmacro %}
+
+{##
  # The request type derived from operation data
  #}
 {% macro requestTypeName(operation) -%}{{ operation.operationId | capitalizeFirst }}T{% endmacro %}
@@ -511,3 +517,9 @@
   () => ({})
   {% endif %}
 {% endmacro %}
+
+{##
+ # Given an IHeaderParamenterInfo, it renders an header producer that links the parameter name with expected header
+ # example: { name: 'token', headerName: 'Authorization' } -> ({ token }) => ({ "Authorization": token })
+ #}
+{% macro requestParamsType(operation) -%}ReplaceRequestParams<{{ requestTypeName(operation) }},RequestParams<{{ requestTypeName(operation) }}>>{% endmacro %}


### PR DESCRIPTION
There was a type error in the generated client. The compiler could not calculate the return type as `testAuthBearerT` _is a private member_ (`testAuthBearerT` is just an example).

> ⚠️ this error isn't caught by our unit/e2e tests, I spotted it once I tried to build a generated sdk by itself. This is probably due to the fact that we use `ts-jest` utility. It's supposed to keep the very same typescript behavior, anyway  It's not the first time it has a slightly different outcome. `ts-jest` is very helpful as it smooths test execution, anyway we should consider the idea of rid it and just build code upfront before tests. 

```typescript
// before
export function Client( /* args */ ): {
  readonly testAuthBearer: TypeofApiCall<typeof testAuthBearerT>;
} {
  // ...
  const testAuthBearerT: ReplaceRequestParams<
    TestAuthBearerT,
    RequestParams<TestAuthBearerT>
  > = { /* ... */ };
  const testAuthBearer = createFetchRequestForApi(testAuthBearerT, options)

  return {
    testAuthBearer
  };
}

// after
export function Client( /* args */ ): {
  readonly testAuthBearer: TypeofApiCall<
    ReplaceRequestParams<TestAuthBearerT, RequestParams<TestAuthBearerT>>
  >;
} {
  // ...
  const testAuthBearerT: ReplaceRequestParams<
    TestAuthBearerT,
    RequestParams<TestAuthBearerT>
  > = { /* ... */ };
  const testAuthBearer = createFetchRequestForApi(testAuthBearerT, options)

  return {
    testAuthBearer
  };
}
```