### PR TITLE
[#172494831] Wrap operations with default parameters (alternative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ done
 ### Generated client
 The http client is defined in `client.ts` module file. It exports the following:
 * a type `Client<K>` which define the set of operations
-* * `K` a union of keys that represent the parameters omitted by the operations (see `transformEach` below)
+* * `K` a union of keys that represent the parameters omitted by the operations (see `withDefaults` below)
 * a function `createClient<K>(parameters): Client<K>` accepting the following parameters:
 * * `baseUrl` the base hostname of the api, including protocol and port
 * * `fetchApi` an implementation of the [fetch-api](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) as defined in your platform (for example: `node-fetch` if you are in node)
@@ -102,10 +102,10 @@ The http client is defined in `client.ts` module file. It exports the following:
 
 #### Example
 ```typescript
-import { createClient, DefaultTransformEach } from "my-api/client";
+import { createClient, WithDefaultsT } from "my-api/client";
 
 
-// Without transformEach
+// Without withDefaults
 const simpleClient: Client = createClient({
     baseUrl: `http://localhost:8080`,
     fetchApi: (nodeFetch as any) as typeof fetch
@@ -118,7 +118,7 @@ const result = await simpleClient.myOperation({
 });
 
 
-// with transformEach
+// with withDefaults
 const withBearer: WithDefaultsT<"Bearer"> = 
     wrappedOperation => 
         params => { // wrappedOperation and params are correctly inferred

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ Options:
                                                              [string] [required]
   --ts-spec-file          If defined, converts the OpenAPI specs to TypeScript
                           source and writes it to this file             [string]
-  --request-types         Generate request types (experimental, default: false)
+  --request-types         Generate request types (default: false)
                                                                 [default: false]
-  --response-decoders     Generate response decoders (experimental, default:
+  --response-decoders     Generate response decoders (default:
                           false, implies --request-types)       [default: false]
   --client                Generate request client SDK           [default: false]
-  --default-success-type  Default type for success responses (experimental,
+  --default-success-type  Default type for success responses (
                           default: 'undefined')  [string] [default: "undefined"]
-  --default-error-type    Default type for error responses (experimental,
+  --default-error-type    Default type for error responses (
                           default: 'undefined')  [string] [default: "undefined"]
   --help                  Show help                                    [boolean]
 ```
@@ -96,8 +96,8 @@ The http client is defined in `client.ts` module file. It exports the following:
 * * `baseUrl` the base hostname of the api, including protocol and port
 * * `fetchApi` an implementation of the [fetch-api](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) as defined in your platform (for example: `node-fetch` if you are in node)
 * * `basePath` (optional) if defined, is appended to `baseUrl` for every operations. Its default is the basePath value defined in the specification
-* * `transformEach` (optional) an adapter function that wraps every operations. It may shadow some parameters to the wrapped operations. The use case is: you have a parameter which is common to many operations and you want it to be fixed (example: a session token). 
-* a type `DefaultTransformEach<K>` that defines an adapter function to be used as `transformEach`
+* * `withDefaults` (optional) an adapter function that wraps every operations. It may shadow some parameters to the wrapped operations. The use case is: you have a parameter which is common to many operations and you want it to be fixed (example: a session token). 
+* a type `WithDefaultsT<K>` that defines an adapter function to be used as `withDefaults`
 * * `K` the set of parameters that the adapter will shadow
 
 #### Example
@@ -106,7 +106,7 @@ import { createClient, DefaultTransformEach } from "my-api/client";
 
 
 // Without transformEach
-const simpleClient = createClient({
+const simpleClient: Client = createClient({
     baseUrl: `http://localhost:8080`,
     fetchApi: (nodeFetch as any) as typeof fetch
 });
@@ -119,7 +119,7 @@ const result = await simpleClient.myOperation({
 
 
 // with transformEach
-const withBearer: DefaultTransformEach<"Bearer"> = 
+const withBearer: WithDefaultsT<"Bearer"> = 
     wrappedOperation => 
         params => { // wrappedOperation and params are correctly inferred
             return wrappedOperation({
@@ -128,10 +128,10 @@ const withBearer: DefaultTransformEach<"Bearer"> =
             });
           };
 //  this is the same of using createClient<"Bearer">. K type is being inferred from withBearer
-const clientWithGlobalToken = createClient({
+const clientWithGlobalToken: Client<"Bearer"> = createClient({
     baseUrl: `http://localhost:8080`,
     fetchApi: (nodeFetch as any) as typeof fetch,
-    transformEach: withBearer
+    withDefaults: withBearer
 });
 
 // myOperation doesn't require "Bearer" anymore, as it's defined in "withBearer" adapter 
@@ -171,9 +171,9 @@ Code generation options:
                                                                  [default: true]
   --out-dir, -o           Output directory to store generated definition files
                                                              [string] [required]
-  --default-success-type  Default type for success responses (experimental,
+  --default-success-type  Default type for success responses (
                           default: 'undefined')  [string] [default: "undefined"]
-  --default-error-type    Default type for error responses (experimental,
+  --default-error-type    Default type for error responses (
                           default: 'undefined')  [string] [default: "undefined"]
 
 Options:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Digital Citizenship initiative.
 
 To add the tools to a project:
 
-```
+```sh
 $ yarn add -D io-utils
 ```
 ## important: check your openapi spec
@@ -14,7 +14,7 @@ If you need to keep the references between the generated classes, the specificat
 example:
 
 if the `Pets` schema uses the `Pet`, import both into the main document 
-```
+```yaml
 components:
   schemas:
     Pets:
@@ -23,7 +23,7 @@ components:
         $ref: "animal.yaml#/Pet"
 ```
 *animal.yaml*
-```
+```yaml
 Pets:
   type: array
   items:
@@ -46,26 +46,39 @@ In simple terms it converts an OpenAPI spec like [this one](https://github.com/t
 
 * A TypeScript [representation of the specs](https://github.com/teamdigitale/digital-citizenship-functions/blob/6798225bd725a42753b16375ce18a954a268f9b6/lib/api/public_api_v1.ts).
 * An [io-ts](https://github.com/gcanti/io-ts) type definitions for [each API definition](https://github.com/teamdigitale/digital-citizenship-functions/tree/6798225bd725a42753b16375ce18a954a268f9b6/lib/api/definitions) that provides compile time types and runtime validation.
+* A http client exposing API operations as a collection of Typescript functions
 
 Note: the generated models requires the runtime dependency `italia-ts-commons`.
 
+
 ### Usage
 
-```
+```sh
 $ gen-api-models --help
 Options:
-  --version       Show version number                                  [boolean]
-  --api-spec      Path to input OpenAPI spec file            [string] [required]
-  --out-dir       Output directory to store generated definition files
+  --version               Show version number                          [boolean]
+  --api-spec              Path to input OpenAPI spec file    [string] [required]
+  --strict                Generate strict interfaces (default: true)
+                                                                 [default: true]
+  --out-dir               Output directory to store generated definition files
                                                              [string] [required]
-  --ts-spec-file  If defined, converts the OpenAPI specs to TypeScript source
-                  and writes it to this file                            [string]
-  --help          Show help                                            [boolean]
+  --ts-spec-file          If defined, converts the OpenAPI specs to TypeScript
+                          source and writes it to this file             [string]
+  --request-types         Generate request types (experimental, default: false)
+                                                                [default: false]
+  --response-decoders     Generate response decoders (experimental, default:
+                          false, implies --request-types)       [default: false]
+  --client                Generate request client SDK           [default: false]
+  --default-success-type  Default type for success responses (experimental,
+                          default: 'undefined')  [string] [default: "undefined"]
+  --default-error-type    Default type for error responses (experimental,
+                          default: 'undefined')  [string] [default: "undefined"]
+  --help                  Show help                                    [boolean]
 ```
 
 Example:
 
-```
+```sh
 $ gen-api-models --api-spec ./api/public_api_v1.yaml --out-dir ./lib/api/definitions --ts-spec-file ./lib/api/public_api_v1.ts
 Writing TS Specs to lib/api/public_api_v1.ts
 ProblemJson -> lib/api/definitions/ProblemJson.ts
@@ -74,6 +87,100 @@ NotificationChannelStatusValue -> lib/api/definitions/NotificationChannelStatusV
 ...
 done
 ```
+
+### Generated client
+The http client is defined in `client.ts` module file. It exports the following:
+* a type `Client<K>` which define the set of operations
+* * `K` a union of keys that represent the parameters omitted by the operations (see `transformEach` below)
+* a function `createClient<K>(parameters): Client<K>` accepting the following parameters:
+* * `baseUrl` the base hostname of the api, including protocol and port
+* * `fetchApi` an implementation of the [fetch-api](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) as defined in your platform (for example: `node-fetch` if you are in node)
+* * `basePath` (optional) if defined, is appended to `baseUrl` for every operations. Its default is the basePath value defined in the specification
+* * `transformEach` (optional) an adapter function that wraps every operations. It may shadow some parameters to the wrapped operations. The use case is: you have a parameter which is common to many operations and you want it to be fixed (example: a session token). 
+* a type `DefaultTransformEach<K>` that defines an adapter function to be used as `transformEach`
+* * `K` the set of parameters that the adapter will shadow
+
+#### Example
+```typescript
+import { createClient, DefaultTransformEach } from "my-api/client";
+
+
+// Without transformEach
+const simpleClient = createClient({
+    baseUrl: `http://localhost:8080`,
+    fetchApi: (nodeFetch as any) as typeof fetch
+});
+
+// myOperation is defined to accept { id: string; Bearer: string; }
+const result = await simpleClient.myOperation({
+    id: "id123",
+    Bearer: "VALID_TOKEN"
+});
+
+
+// with transformEach
+const withBearer: DefaultTransformEach<"Bearer"> = 
+    wrappedOperation => 
+        params => { // wrappedOperation and params are correctly inferred
+            return wrappedOperation({
+              ...params,
+              Bearer: "VALID_TOKEN"
+            });
+          };
+//  this is the same of using createClient<"Bearer">. K type is being inferred from withBearer
+const clientWithGlobalToken = createClient({
+    baseUrl: `http://localhost:8080`,
+    fetchApi: (nodeFetch as any) as typeof fetch,
+    transformEach: withBearer
+});
+
+// myOperation doesn't require "Bearer" anymore, as it's defined in "withBearer" adapter 
+const result = await clientWithGlobalToken.myOperation({
+    id: "id123"
+});
+```
+
+
+## gen-api-sdk
+Bundles a generated api models and clients into a node package ready to be published into a registry.
+
+### Usage
+```sh
+$ gen-api-sdk --help
+Package options:
+  --package-name, -n, --name          Name of the generated package
+                                                             [string] [required]
+  --package-version, -V               Version of the generated package
+                                                             [string] [required]
+  --package-description, -d, --desc   Description of the package
+                                                             [string] [required]
+  --package-registry, -r, --registry  Url of the registry the package is
+                                      published in                      [string]
+  --package-access, -x, --access      Either 'public' or 'private', depending of
+                                      the accessibility of the package in the
+                                      registry
+                                         [string] [choices: "public", "private"]
+  --package-author, -a, --author      The author of the API exposed
+                                                             [string] [required]
+  --package-license, -L, --license    The license of the API Exposed
+                                                             [string] [required]
+
+Code generation options:
+  --api-spec, -i          Path to input OpenAPI spec file    [string] [required]
+  --strict                Generate strict interfaces (default: true)
+                                                                 [default: true]
+  --out-dir, -o           Output directory to store generated definition files
+                                                             [string] [required]
+  --default-success-type  Default type for success responses (experimental,
+                          default: 'undefined')  [string] [default: "undefined"]
+  --default-error-type    Default type for error responses (experimental,
+                          default: 'undefined')  [string] [default: "undefined"]
+
+Options:
+  --version  Show version number                                       [boolean]
+  --help     Show help                                                 [boolean]
+```
+
 
 ### Requirements
 

--- a/e2e/src/__tests__/be/client.test.ts
+++ b/e2e/src/__tests__/be/client.test.ts
@@ -1,6 +1,6 @@
 import nodeFetch from "node-fetch";
 import config from "../../config";
-import { createClient, DefaultTransformEach } from "../../generated/be/client";
+import { createClient, WithDefaultsT } from "../../generated/be/client";
 
 const { skipClient } = config;
 const { mockPort, isSpecEnabled } = config.specs.be;
@@ -40,7 +40,7 @@ describeSuite("Http client generated from BE API spec", () => {
     });
 
     it("should use a common token", async () => {
-      const withBearer: DefaultTransformEach<"Bearer"> = op => params => {
+      const withBearer: WithDefaultsT<"Bearer"> = op => params => {
         return op({
           ...params,
           Bearer: VALID_TOKEN
@@ -51,7 +51,7 @@ describeSuite("Http client generated from BE API spec", () => {
         baseUrl: `http://localhost:${mockPort}`,
         basePath: "",
         fetchApi: (nodeFetch as any) as typeof fetch,
-        transformEach: withBearer
+        withDefaults: withBearer
       });
 
       // please not we're not passing Bearer
@@ -144,14 +144,14 @@ describeSuite("Http client generated from BE API spec", () => {
       );
     });
 
-    it("should pass parameters correctly to fetch (with trasformEach)", async () => {
+    it("should pass parameters correctly to fetch (using dafault parameters adapter)", async () => {
       const spiedFetch = jest.fn(() => ({
         status: 200,
         json: async () => ({}),
         headers: {}
       }));
 
-      const withBearer: DefaultTransformEach<"Bearer"> = op => params => {
+      const withBearer: WithDefaultsT<"Bearer"> = op => params => {
         return op({
           ...params,
           Bearer: VALID_TOKEN
@@ -164,7 +164,7 @@ describeSuite("Http client generated from BE API spec", () => {
         // tslint:disable-next-line: no-any
         fetchApi: (spiedFetch as any) as typeof fetch,
         basePath: "",
-        transformEach: withBearer
+        withDefaults: withBearer
       });
 
       await getVisibleServices({

--- a/e2e/src/__tests__/be/client.test.ts
+++ b/e2e/src/__tests__/be/client.test.ts
@@ -1,6 +1,13 @@
 import nodeFetch from "node-fetch";
 import config from "../../config";
-import { Client } from "../../generated/be/client";
+import { createClient, OmitApiCallParams } from "../../generated/be/client";
+import {
+  GetServiceT,
+  GetServicesByRecipientT,
+  GetVisibleServicesT,
+  StartEmailValidationProcessT,
+  GetUserMetadataT
+} from "../../generated/be/requestTypes";
 
 const { skipClient } = config;
 const { mockPort, isSpecEnabled } = config.specs.be;
@@ -13,20 +20,57 @@ const INVALID_TOKEN = undefined;
 
 describeSuite("Http client generated from BE API spec", () => {
   it("should be a valid module", () => {
-    expect(Client).toBeDefined();
-    expect(Client).toEqual(expect.any(Function));
+    expect(createClient).toBeDefined();
+    expect(createClient).toEqual(expect.any(Function));
   });
 
   describe("getService", () => {
     it("should retrieve a single service", async () => {
-      const { getService } = Client(
-        `http://localhost:${mockPort}`,
-        (nodeFetch as any) as typeof fetch,
-        ""
-      );
+      const { getService } = createClient({
+        baseUrl: `http://localhost:${mockPort}`,
+        fetchApi: (nodeFetch as any) as typeof fetch,
+        basePath: ""
+      });
 
       const result = await getService({
         Bearer: VALID_TOKEN,
+        service_id: "service123"
+      });
+
+      result.fold(
+        (e: any) => fail(e),
+        response => {
+          expect(response.status).toBe(200);
+          expect(response.value).toEqual(expect.any(Object));
+        }
+      );
+    });
+
+    it("should use a common token", async () => {
+      const withBearer: OmitApiCallParams<
+        // tslint:disable-next-line: max-union-size
+        | GetServiceT
+        | GetServicesByRecipientT
+        | GetVisibleServicesT
+        | StartEmailValidationProcessT
+        | GetUserMetadataT,
+        "Bearer"
+      > = op => params => {
+        return op({
+          ...params,
+          Bearer: VALID_TOKEN
+        });
+      };
+
+      const { getService } = createClient<"Bearer">({
+        baseUrl: `http://localhost:${mockPort}`,
+        basePath: "",
+        fetchApi: (nodeFetch as any) as typeof fetch,
+        transformEach: withBearer
+      });
+
+      // please not we're not passing Bearer
+      const result = await getService({
         service_id: "service123"
       });
 
@@ -42,11 +86,11 @@ describeSuite("Http client generated from BE API spec", () => {
 
   describe("getVisibleServices", () => {
     it("should retrieve a list of visible services", async () => {
-      const { getVisibleServices } = Client(
-        `http://localhost:${mockPort}`,
-        (nodeFetch as any) as typeof fetch,
-        ""
-      );
+      const { getVisibleServices } = createClient({
+        baseUrl: `http://localhost:${mockPort}`,
+        fetchApi: (nodeFetch as any) as typeof fetch,
+        basePath: ""
+      });
 
       const result = await getVisibleServices({
         Bearer: VALID_TOKEN
@@ -66,11 +110,11 @@ describeSuite("Http client generated from BE API spec", () => {
     });
 
     it("should accept pagination", async () => {
-      const { getVisibleServices } = Client(
-        `http://localhost:${mockPort}`,
-        (nodeFetch as any) as typeof fetch,
-        ""
-      );
+      const { getVisibleServices } = createClient({
+        baseUrl: `http://localhost:${mockPort}`,
+        fetchApi: (nodeFetch as any) as typeof fetch,
+        basePath: ""
+      });
 
       const result = await getVisibleServices({
         Bearer: VALID_TOKEN,
@@ -96,14 +140,57 @@ describeSuite("Http client generated from BE API spec", () => {
         json: async () => ({}),
         headers: {}
       }));
-      const { getVisibleServices } = Client(
-        `http://localhost:${mockPort}`,
-        (spiedFetch as any) as typeof fetch,
-        ""
-      );
+      const { getVisibleServices } = createClient({
+        baseUrl: `http://localhost:${mockPort}`,
+        fetchApi: (spiedFetch as any) as typeof fetch,
+        basePath: ""
+      });
 
       await getVisibleServices({
         Bearer: VALID_TOKEN,
+        cursor: "my_cursor"
+      });
+
+      expect(spiedFetch).toBeCalledWith(
+        expect.stringContaining("cursor=my_cursor"),
+        expect.objectContaining({
+          headers: { Authorization: expect.stringContaining(VALID_TOKEN) }
+        })
+      );
+    });
+
+    it("should pass parameters correctly to fetch (with trasformEach)", async () => {
+      const spiedFetch = jest.fn(() => ({
+        status: 200,
+        json: async () => ({}),
+        headers: {}
+      }));
+
+      const withBearer: OmitApiCallParams<
+        // tslint:disable-next-line: max-union-size
+        | GetServiceT
+        | GetServicesByRecipientT
+        | GetVisibleServicesT
+        | StartEmailValidationProcessT
+        | GetUserMetadataT,
+        "Bearer"
+      > = op => params => {
+        return op({
+          ...params,
+          Bearer: VALID_TOKEN
+        });
+      };
+
+      // please note we're not passing a K type to createClient, is being inferred from witBearer
+      const { getVisibleServices } = createClient({
+        baseUrl: `http://localhost:${mockPort}`,
+        // tslint:disable-next-line: no-any
+        fetchApi: (spiedFetch as any) as typeof fetch,
+        basePath: "",
+        transformEach: withBearer
+      });
+
+      await getVisibleServices({
         cursor: "my_cursor"
       });
 

--- a/e2e/src/__tests__/be/client.test.ts
+++ b/e2e/src/__tests__/be/client.test.ts
@@ -1,13 +1,6 @@
 import nodeFetch from "node-fetch";
 import config from "../../config";
-import { createClient, OmitApiCallParams } from "../../generated/be/client";
-import {
-  GetServiceT,
-  GetServicesByRecipientT,
-  GetVisibleServicesT,
-  StartEmailValidationProcessT,
-  GetUserMetadataT
-} from "../../generated/be/requestTypes";
+import { createClient, DefaultTransformEach } from "../../generated/be/client";
 
 const { skipClient } = config;
 const { mockPort, isSpecEnabled } = config.specs.be;
@@ -47,15 +40,7 @@ describeSuite("Http client generated from BE API spec", () => {
     });
 
     it("should use a common token", async () => {
-      const withBearer: OmitApiCallParams<
-        // tslint:disable-next-line: max-union-size
-        | GetServiceT
-        | GetServicesByRecipientT
-        | GetVisibleServicesT
-        | StartEmailValidationProcessT
-        | GetUserMetadataT,
-        "Bearer"
-      > = op => params => {
+      const withBearer: DefaultTransformEach<"Bearer"> = op => params => {
         return op({
           ...params,
           Bearer: VALID_TOKEN
@@ -166,15 +151,7 @@ describeSuite("Http client generated from BE API spec", () => {
         headers: {}
       }));
 
-      const withBearer: OmitApiCallParams<
-        // tslint:disable-next-line: max-union-size
-        | GetServiceT
-        | GetServicesByRecipientT
-        | GetVisibleServicesT
-        | StartEmailValidationProcessT
-        | GetUserMetadataT,
-        "Bearer"
-      > = op => params => {
+      const withBearer: DefaultTransformEach<"Bearer"> = op => params => {
         return op({
           ...params,
           Bearer: VALID_TOKEN

--- a/e2e/src/__tests__/test-api/client.test.ts
+++ b/e2e/src/__tests__/test-api/client.test.ts
@@ -35,13 +35,13 @@ describeSuite("Http client generated from Test API spec", () => {
     expect(isRight(result)).toBe(false);
   });
 
-  it("should make a call, with transformEach", async () => {
+  it("should make a call, with default parameters", async () => {
   
     const client = createClient<"bearerToken">({
       baseUrl: `http://localhost:${mockPort}`,
       fetchApi: (nodeFetch as any) as typeof fetch,
       basePath: "",
-      transformEach: (op: any) => (params: any) => op({ ...params, bearerToken: 'abc123'})
+      withDefaults: (op: any) => (params: any) => op({ ...params, bearerToken: 'abc123'})
     });
 
     expect(client.testAuthBearer).toEqual(expect.any(Function));

--- a/e2e/src/__tests__/test-api/client.test.ts
+++ b/e2e/src/__tests__/test-api/client.test.ts
@@ -1,4 +1,4 @@
-import { Client } from "../../generated/testapi/client";
+import { createClient } from "../../generated/testapi/client";
 import { isRight, Either } from "fp-ts/lib/Either";
 import nodeFetch from "node-fetch";
 import config from "../../config";
@@ -14,21 +14,41 @@ const { generatedFilesDir, mockPort, isSpecEnabled } = config.specs.testapi;
 const describeSuite = skipClient || !isSpecEnabled ? describe.skip : describe;
 
 describeSuite("Http client generated from Test API spec", () => {
-  
   it("should be a valid module", async () => {
-    expect(Client).toBeDefined();
-    expect(Client).toEqual(expect.any(Function));
+    expect(createClient).toBeDefined();
+    expect(createClient).toEqual(expect.any(Function));
   });
 
   it("should make a call", async () => {
-    const client = Client(
-      `http://localhost:${mockPort}`,
-      (nodeFetch as any) as typeof fetch
-    );
+    const client = createClient({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: (nodeFetch as any) as typeof fetch,
+      basePath: "",
+    });
 
     expect(client.testAuthBearer).toEqual(expect.any(Function));
-    // @ts-ignore because testAuthBearer has different signature but still I want to check this behavior
-    const result = await client.testAuthBearer({});
+
+    const result = await client.testAuthBearer({
+      bearerToken: "acb123",
+      qr: "acb123"
+    });
+    expect(isRight(result)).toBe(false);
+  });
+
+  it("should make a call, with transformEach", async () => {
+  
+    const client = createClient<"bearerToken">({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: (nodeFetch as any) as typeof fetch,
+      basePath: "",
+      trasnformEach: (op: any) => (params: any) => op({ ...params, bearerToken: 'abc123'})
+    });
+
+    expect(client.testAuthBearer).toEqual(expect.any(Function));
+
+    const result = await client.testAuthBearer({
+      qr: "acb123"
+    });
     expect(isRight(result)).toBe(false);
   });
 });

--- a/e2e/src/__tests__/test-api/client.test.ts
+++ b/e2e/src/__tests__/test-api/client.test.ts
@@ -41,7 +41,7 @@ describeSuite("Http client generated from Test API spec", () => {
       baseUrl: `http://localhost:${mockPort}`,
       fetchApi: (nodeFetch as any) as typeof fetch,
       basePath: "",
-      trasnformEach: (op: any) => (params: any) => op({ ...params, bearerToken: 'abc123'})
+      transformEach: (op: any) => (params: any) => op({ ...params, bearerToken: 'abc123'})
     });
 
     expect(client.testAuthBearer).toEqual(expect.any(Function));

--- a/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
+++ b/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
@@ -521,25 +521,99 @@ import {
   testFileUploadDefaultDecoder
 } from \\"./requestTypes\\";
 
-export function Client(
-  baseUrl: string,
-  // tslint:disable-next-line:no-any
-  fetchApi: typeof fetch,
-  basePath: string = \\"/api/v1\\"
-): {
+/**
+ * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
+ * @param ApiT the type which defines the operation to expose
+ * @param K the parameter to omit. undefined means no parameters will be omitted
+ */
+export type OmitApiCallParams<ApiT, K = undefined> = (
+  op: TypeofApiCall<ApiT>
+) => K extends string
+  ? TypeofApiCall<ReplaceRequestParams<ApiT, Omit<RequestParams<ApiT>, K>>>
+  : TypeofApiCall<ApiT>;
+
+/**
+ * Defines a collection of api operations
+ * @param K name of the parameters that the Clients masks from the operations
+ */
+export type Client<K extends string = \\"\\"> = {
   readonly testAuthBearer: TypeofApiCall<
-    ReplaceRequestParams<TestAuthBearerT, RequestParams<TestAuthBearerT>>
+    ReplaceRequestParams<
+      TestAuthBearerT,
+      Omit<RequestParams<TestAuthBearerT>, K>
+    >
   >;
+
   readonly testMultipleSuccess: TypeofApiCall<
     ReplaceRequestParams<
       TestMultipleSuccessT,
-      RequestParams<TestMultipleSuccessT>
+      Omit<RequestParams<TestMultipleSuccessT>, K>
     >
   >;
+
   readonly testFileUpload: TypeofApiCall<
-    ReplaceRequestParams<TestFileUploadT, RequestParams<TestFileUploadT>>
+    ReplaceRequestParams<
+      TestFileUploadT,
+      Omit<RequestParams<TestFileUploadT>, K>
+    >
   >;
-} {
+};
+
+/**
+ * Identity function for OmitApiCallParams.
+ * @param op the operation to be wrapped
+ */
+const noTransform: OmitApiCallParams<
+  TestAuthBearerT | TestMultipleSuccessT | TestFileUploadT
+> = (
+  operation: TypeofApiCall<TestAuthBearerT> &
+    TypeofApiCall<TestMultipleSuccessT> &
+    TypeofApiCall<TestFileUploadT>
+) => operation;
+
+/**
+ * Create an instance of a client
+ * @param params hash map of parameters thata define the client:
+ *  - baseUrl: the base url for every api call (required)
+ *  - fetchApi: an implementation of the fetch() web API, depending on the platform (required)
+ *  - basePath: optional path to be appended to the baseUrl
+ *  - transformEach: optional adapter to be applied to every operation, to omit some paramenters
+ * @returns a collection of api operations
+ */
+export function createClient<K extends string>(params: {
+  baseUrl: string;
+  // tslint:disable-next-line:no-any
+  fetchApi: typeof fetch;
+  transformEach: OmitApiCallParams<TestAuthBearerT, K> &
+    OmitApiCallParams<TestMultipleSuccessT, K> &
+    OmitApiCallParams<TestFileUploadT, K>;
+  basePath?: string;
+}): Client<K>;
+export function createClient(params: {
+  baseUrl: string;
+  // tslint:disable-next-line:no-any
+  fetchApi: typeof fetch;
+  transformEach?: undefined;
+  basePath?: string;
+}): Client;
+export function createClient<K extends string>({
+  baseUrl,
+  // tslint:disable-next-line:no-any
+  fetchApi,
+  transformEach,
+  basePath = \\"/api/v1\\"
+}: {
+  baseUrl: string;
+  // tslint:disable-next-line:no-any
+  fetchApi: typeof fetch;
+  transformEach?: K extends \\"\\"
+    ? undefined
+    : OmitApiCallParams<TestAuthBearerT, K> &
+        OmitApiCallParams<TestMultipleSuccessT, K> &
+        OmitApiCallParams<TestFileUploadT, K>;
+
+  basePath?: string;
+}) {
   const options = {
     baseUrl,
     fetchApi
@@ -560,7 +634,9 @@ export function Client(
 
     query: ({ qo, qr, cursor }) => ({ qo, qr, cursor })
   };
-  const testAuthBearer = createFetchRequestForApi(testAuthBearerT, options);
+  const testAuthBearer = (transformEach || noTransform)(
+    createFetchRequestForApi(testAuthBearerT, options)
+  );
 
   const testMultipleSuccessT: ReplaceRequestParams<
     TestMultipleSuccessT,
@@ -575,9 +651,8 @@ export function Client(
 
     query: () => ({})
   };
-  const testMultipleSuccess = createFetchRequestForApi(
-    testMultipleSuccessT,
-    options
+  const testMultipleSuccess = (transformEach || noTransform)(
+    createFetchRequestForApi(testMultipleSuccessT, options)
   );
 
   const testFileUploadT: ReplaceRequestParams<
@@ -595,7 +670,9 @@ export function Client(
 
     query: () => ({})
   };
-  const testFileUpload = createFetchRequestForApi(testFileUploadT, options);
+  const testFileUpload = (transformEach || noTransform)(
+    createFetchRequestForApi(testFileUploadT, options)
+  );
 
   return {
     testAuthBearer,
@@ -603,8 +680,6 @@ export function Client(
     testFileUpload
   };
 }
-
-export type Client = typeof Client;
 "
 `;
 

--- a/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
+++ b/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
@@ -537,7 +537,7 @@ export type OmitApiCallParams<ApiT, K = undefined> = (
  * @param ApiT the type which defines the operation to expose
  * @param K the parameter to omit. undefined means no parameters will be omitted
  */
-export type DefaultTransformEach<K = undefined> = OmitApiCallParams<
+export type WithDefaultsT<K = undefined> = OmitApiCallParams<
   TestAuthBearerT | TestMultipleSuccessT | TestFileUploadT,
   K
 >;
@@ -573,7 +573,7 @@ export type Client<K extends string = \\"\\"> = {
  * Identity function for OmitApiCallParams.
  * @param op the operation to be wrapped
  */
-const noTransform: DefaultTransformEach = (
+const noDefaults: WithDefaultsT = (
   operation: TypeofApiCall<TestAuthBearerT> &
     TypeofApiCall<TestMultipleSuccessT> &
     TypeofApiCall<TestFileUploadT>
@@ -585,14 +585,14 @@ const noTransform: DefaultTransformEach = (
  *  - baseUrl: the base url for every api call (required)
  *  - fetchApi: an implementation of the fetch() web API, depending on the platform (required)
  *  - basePath: optional path to be appended to the baseUrl
- *  - transformEach: optional adapter to be applied to every operation, to omit some paramenters
+ *  - withDefaults: optional adapter to be applied to every operation, to omit some paramenters
  * @returns a collection of api operations
  */
 export function createClient<K extends string>(params: {
   baseUrl: string;
   // tslint:disable-next-line:no-any
   fetchApi: typeof fetch;
-  transformEach: OmitApiCallParams<TestAuthBearerT, K> &
+  withDefaults: OmitApiCallParams<TestAuthBearerT, K> &
     OmitApiCallParams<TestMultipleSuccessT, K> &
     OmitApiCallParams<TestFileUploadT, K>;
   basePath?: string;
@@ -601,20 +601,20 @@ export function createClient(params: {
   baseUrl: string;
   // tslint:disable-next-line:no-any
   fetchApi: typeof fetch;
-  transformEach?: undefined;
+  withDefaults?: undefined;
   basePath?: string;
 }): Client;
 export function createClient<K extends string>({
   baseUrl,
   // tslint:disable-next-line:no-any
   fetchApi,
-  transformEach,
+  withDefaults,
   basePath = \\"/api/v1\\"
 }: {
   baseUrl: string;
   // tslint:disable-next-line:no-any
   fetchApi: typeof fetch;
-  transformEach?: K extends \\"\\"
+  withDefaults?: K extends \\"\\"
     ? undefined
     : OmitApiCallParams<TestAuthBearerT, K> &
         OmitApiCallParams<TestMultipleSuccessT, K> &
@@ -642,7 +642,7 @@ export function createClient<K extends string>({
 
     query: ({ qo, qr, cursor }) => ({ qo, qr, cursor })
   };
-  const testAuthBearer = (transformEach || noTransform)(
+  const testAuthBearer = (withDefaults || noDefaults)(
     createFetchRequestForApi(testAuthBearerT, options)
   );
 
@@ -659,7 +659,7 @@ export function createClient<K extends string>({
 
     query: () => ({})
   };
-  const testMultipleSuccess = (transformEach || noTransform)(
+  const testMultipleSuccess = (withDefaults || noDefaults)(
     createFetchRequestForApi(testMultipleSuccessT, options)
   );
 
@@ -678,7 +678,7 @@ export function createClient<K extends string>({
 
     query: () => ({})
   };
-  const testFileUpload = (transformEach || noTransform)(
+  const testFileUpload = (withDefaults || noDefaults)(
     createFetchRequestForApi(testFileUploadT, options)
   );
 

--- a/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
+++ b/src/__tests__/__snapshots__/gen-api-models.test.ts.snap
@@ -533,6 +533,16 @@ export type OmitApiCallParams<ApiT, K = undefined> = (
   : TypeofApiCall<ApiT>;
 
 /**
+ * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
+ * @param ApiT the type which defines the operation to expose
+ * @param K the parameter to omit. undefined means no parameters will be omitted
+ */
+export type DefaultTransformEach<K = undefined> = OmitApiCallParams<
+  TestAuthBearerT | TestMultipleSuccessT | TestFileUploadT,
+  K
+>;
+
+/**
  * Defines a collection of api operations
  * @param K name of the parameters that the Clients masks from the operations
  */
@@ -563,9 +573,7 @@ export type Client<K extends string = \\"\\"> = {
  * Identity function for OmitApiCallParams.
  * @param op the operation to be wrapped
  */
-const noTransform: OmitApiCallParams<
-  TestAuthBearerT | TestMultipleSuccessT | TestFileUploadT
-> = (
+const noTransform: DefaultTransformEach = (
   operation: TypeofApiCall<TestAuthBearerT> &
     TypeofApiCall<TestMultipleSuccessT> &
     TypeofApiCall<TestFileUploadT>

--- a/templates/client.ts.njk
+++ b/templates/client.ts.njk
@@ -39,6 +39,13 @@ export type OmitApiCallParams<ApiT, K = undefined> = (
   : TypeofApiCall<ApiT>;
 
 /**
+ * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
+ * @param ApiT the type which defines the operation to expose
+ * @param K the parameter to omit. undefined means no parameters will be omitted
+ */
+export type DefaultTransformEach<K = undefined> = OmitApiCallParams<{% for operation in operations %}{{ " | " if loop.index0 else "" }}{{ macro.requestTypeName(operation) }}{% endfor %}, K>
+
+/**
  * Defines a collection of api operations 
  * @param K name of the parameters that the Clients masks from the operations
  */
@@ -55,7 +62,7 @@ export type Client<K extends string = ""> = {
  * Identity function for OmitApiCallParams.
  * @param op the operation to be wrapped
  */
-const noTransform: OmitApiCallParams<{% for operation in operations %}{{ " | " if loop.index0 else "" }}{{ macro.requestTypeName(operation) }}{% endfor %}> = (
+const noTransform: DefaultTransformEach = (
   operation: {% for operation in operations %}{% if loop.index0 %}{% raw %} & {% endraw %}{% endif %}TypeofApiCall<{{ macro.requestTypeName(operation) }}>{% endfor %}
 ) => operation;
 

--- a/templates/client.ts.njk
+++ b/templates/client.ts.njk
@@ -26,19 +26,83 @@ import {
 } from "./requestTypes";
 {% endif%}
 
-{% set moduleName = "Client" %}
 
-export function {{ moduleName }}(
-  baseUrl: string,
+/**
+ * Defines an adapter for TypeofApiCall which omit one or more parameters in the signature
+ * @param ApiT the type which defines the operation to expose
+ * @param K the parameter to omit. undefined means no parameters will be omitted
+ */
+export type OmitApiCallParams<ApiT, K = undefined> = (
+  op: TypeofApiCall<ApiT>
+) => K extends string
+  ? TypeofApiCall<ReplaceRequestParams<ApiT, Omit<RequestParams<ApiT>, K>>>
+  : TypeofApiCall<ApiT>;
+
+/**
+ * Defines a collection of api operations 
+ * @param K name of the parameters that the Clients masks from the operations
+ */
+export type Client<K extends string = ""> = {
+{% for operation in operations %}
+  readonly {{ operation.operationId}}: TypeofApiCall<
+    ReplaceRequestParams<{{ macro.requestTypeName(operation) }}, Omit<RequestParams<{{ macro.requestTypeName(operation) }}>, K>>
+  >;
+{% endfor %}
+};
+
+
+/**
+ * Identity function for OmitApiCallParams.
+ * @param op the operation to be wrapped
+ */
+const noTransform: OmitApiCallParams<{% for operation in operations %}{{ " | " if loop.index0 else "" }}{{ macro.requestTypeName(operation) }}{% endfor %}> = (
+  operation: {% for operation in operations %}{% if loop.index0 %}{% raw %} & {% endraw %}{% endif %}TypeofApiCall<{{ macro.requestTypeName(operation) }}>{% endfor %}
+) => operation;
+
+
+
+/**
+ * Create an instance of a client
+ * @param params hash map of parameters thata define the client:
+ *  - baseUrl: the base url for every api call (required)
+ *  - fetchApi: an implementation of the fetch() web API, depending on the platform (required)
+ *  - basePath: optional path to be appended to the baseUrl
+ *  - transformEach: optional adapter to be applied to every operation, to omit some paramenters
+ * @returns a collection of api operations
+ */
+export function createClient<K extends string>(params: {
+  baseUrl: string;
   // tslint:disable-next-line:no-any
-  fetchApi: typeof fetch,
-  basePath: string = "{{ spec.basePath }}"
-): {
-  {% for operation in operations %} readonly {{ operation.operationId }}: TypeofApiCall<{{ macro.requestParamsType(operation) }}>;{% endfor %}
-} {
+  fetchApi: typeof fetch;
+  transformEach: {% for operation in operations %}{% if loop.index0 %}{% raw %} & {% endraw %}{% endif %}OmitApiCallParams<{{ macro.requestTypeName(operation) }}, K>{% endfor %}
+  basePath?: string;
+}): Client<K>;
+export function createClient(params: {
+  baseUrl: string;
+  // tslint:disable-next-line:no-any
+  fetchApi: typeof fetch;
+  transformEach?: undefined;
+  basePath?: string;
+}): Client;
+export function createClient<K extends string>({
+  baseUrl,
+  // tslint:disable-next-line:no-any
+  fetchApi,
+  transformEach,
+  basePath = "/api/v1",
+}: {
+  baseUrl: string;
+  // tslint:disable-next-line:no-any
+  fetchApi: typeof fetch;
+  transformEach?: K extends ""
+    ? undefined
+    : {% for operation in operations %}{% if loop.index0 %}{% raw %} & {% endraw %}{% endif %}OmitApiCallParams<{{ macro.requestTypeName(operation) }}, K>{% endfor %}
+
+  basePath?: string;
+}) {
   const options = {
     baseUrl,
-    fetchApi
+    fetchApi,
   };
 
 
@@ -71,7 +135,7 @@ export function {{ moduleName }}(
     query: () => ({}),
     {% endif %}
   };
-  const {{ operation.operationId }} = createFetchRequestForApi({{ operation.operationId }}T, options);
+  const {{ operation.operationId }} = (transformEach || noTransform)(createFetchRequestForApi({{ operation.operationId }}T, options));
   {% endfor %}
 
   return {
@@ -79,5 +143,4 @@ export function {{ moduleName }}(
   };
 }
 
-export type {{ moduleName }} = typeof {{ moduleName }};
   

--- a/templates/client.ts.njk
+++ b/templates/client.ts.njk
@@ -43,7 +43,7 @@ export type OmitApiCallParams<ApiT, K = undefined> = (
  * @param ApiT the type which defines the operation to expose
  * @param K the parameter to omit. undefined means no parameters will be omitted
  */
-export type DefaultTransformEach<K = undefined> = OmitApiCallParams<{% for operation in operations %}{{ " | " if loop.index0 else "" }}{{ macro.requestTypeName(operation) }}{% endfor %}, K>
+export type WithDefaultsT<K = undefined> = OmitApiCallParams<{% for operation in operations %}{{ " | " if loop.index0 else "" }}{{ macro.requestTypeName(operation) }}{% endfor %}, K>
 
 /**
  * Defines a collection of api operations 
@@ -62,7 +62,7 @@ export type Client<K extends string = ""> = {
  * Identity function for OmitApiCallParams.
  * @param op the operation to be wrapped
  */
-const noTransform: DefaultTransformEach = (
+const noDefaults: WithDefaultsT = (
   operation: {% for operation in operations %}{% if loop.index0 %}{% raw %} & {% endraw %}{% endif %}TypeofApiCall<{{ macro.requestTypeName(operation) }}>{% endfor %}
 ) => operation;
 
@@ -74,34 +74,34 @@ const noTransform: DefaultTransformEach = (
  *  - baseUrl: the base url for every api call (required)
  *  - fetchApi: an implementation of the fetch() web API, depending on the platform (required)
  *  - basePath: optional path to be appended to the baseUrl
- *  - transformEach: optional adapter to be applied to every operation, to omit some paramenters
+ *  - withDefaults: optional adapter to be applied to every operation, to omit some paramenters
  * @returns a collection of api operations
  */
 export function createClient<K extends string>(params: {
   baseUrl: string;
   // tslint:disable-next-line:no-any
   fetchApi: typeof fetch;
-  transformEach: {% for operation in operations %}{% if loop.index0 %}{% raw %} & {% endraw %}{% endif %}OmitApiCallParams<{{ macro.requestTypeName(operation) }}, K>{% endfor %}
+  withDefaults: {% for operation in operations %}{% if loop.index0 %}{% raw %} & {% endraw %}{% endif %}OmitApiCallParams<{{ macro.requestTypeName(operation) }}, K>{% endfor %}
   basePath?: string;
 }): Client<K>;
 export function createClient(params: {
   baseUrl: string;
   // tslint:disable-next-line:no-any
   fetchApi: typeof fetch;
-  transformEach?: undefined;
+  withDefaults?: undefined;
   basePath?: string;
 }): Client;
 export function createClient<K extends string>({
   baseUrl,
   // tslint:disable-next-line:no-any
   fetchApi,
-  transformEach,
+  withDefaults,
   basePath = "/api/v1",
 }: {
   baseUrl: string;
   // tslint:disable-next-line:no-any
   fetchApi: typeof fetch;
-  transformEach?: K extends ""
+  withDefaults?: K extends ""
     ? undefined
     : {% for operation in operations %}{% if loop.index0 %}{% raw %} & {% endraw %}{% endif %}OmitApiCallParams<{{ macro.requestTypeName(operation) }}, K>{% endfor %}
 
@@ -142,7 +142,7 @@ export function createClient<K extends string>({
     query: () => ({}),
     {% endif %}
   };
-  const {{ operation.operationId }} = (transformEach || noTransform)(createFetchRequestForApi({{ operation.operationId }}T, options));
+  const {{ operation.operationId }} = (withDefaults || noDefaults)(createFetchRequestForApi({{ operation.operationId }}T, options));
   {% endfor %}
 
   return {


### PR DESCRIPTION
This is an alternative proposal to #180 .

### What's better
* `transformEach` are way easier to write
* better type inference
* multiple parameters handled (with exceptions, see _caveats_)

### Proposed solution
```typescript
import { createClient, DefaultTransformEach } from "my-api/client";

const withBearer: DefaultTransformEach<"Bearer"> = 
    wrappedOperation => 
        params => { // wrappedOperation and params are correctly inferred
            return wrappedOperation({
              ...params,
              Bearer: "VALID_TOKEN"
            });
          };
//  this is the same of using createClient<"Bearer">. K type is being inferred from withBearer
const { getService } = createClient({
    baseUrl: `http://localhost:${mockPort}`,
    basePath: "",
    fetchApi: (nodeFetch as any) as typeof fetch,
    transformEach: withBearer
});

// getService doesn't require "Bearer" anymore, as it's defined in "withBearer" adapter 
const result = await getService({
    service_id: "service123"
});
```

### Caveats
* ~For a correct type inference of the `transformEach` adapter, there's still the need to explicitly declare all the operation types~ fixed [here](https://github.com/pagopa/io-utils/pull/181/commits/aaa79815e89b9fb372e904481bd12a24526f353e)
* An operation doesn't support more than a wrapped parameters if they cover all operation's parameters.
Example:
```typescript
const { getService } = createClient<"Bearer" | "service_id">({
    baseUrl: `http://localhost:${mockPort}`,
    basePath: "",
    fetchApi: (nodeFetch as any) as typeof fetch,
    transformEach: withBearerAndServiceId
});

// getService would normally accept { service_id, Bearer }. 
// transformed getService now accepts {}
// the following should fail to compile, bot don't. Due to unfixed problems, any object is considered to be a valid parameter object
await getService({ service_id: "service123" });
await getService({ Bearer: "token" });
await getService({ service_id: "service123", Bearer: "token" });
```