### PR TITLE
[#174334136] Bundle openapi spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,23 @@ Options:
 ```
 
 
+## bundle-api-spec
+Takes a given api spec file and resolves its esternal references by creating a new file with only internal refereces
+
+```sh
+$ bundle-api-spec --help
+Code generation options:
+  --api-spec, -i     Path to input OpenAPI spec file         [string] [required]
+  --out-path, -o     Output path of the spec file            [string] [required]
+  --api-version, -V  Version of the api. If provided, override the version in
+                     the original spec file                             [string]
+
+Options:
+  --version  Show version number                                       [boolean]
+  --help     Show help                                                 [boolean]
+```
+
+
 ### Requirements
 
 * `node` version >= 10.8.0

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "main": "dist/index.js",
   "bin": {
     "gen-api-models": "dist/commands/gen-api-models/cli.js",
-    "gen-api-sdk": "dist/commands/gen-api-sdk/cli.js"
+    "gen-api-sdk": "dist/commands/gen-api-sdk/cli.js",
+    "bundle-api-spec": "dist/commands/bundle-api-spec/cli.js"
   },
   "files": [
     "dist/",
@@ -32,6 +33,7 @@
     "nunjucks": "^3.1.2",
     "prettier": "^1.12.1",
     "swagger-parser": "^7.0.0",
+    "write-yaml-file": "^4.1.0",
     "yargs": "^11.1.0"
   },
   "devDependencies": {

--- a/src/commands/bundle-api-spec/cli.ts
+++ b/src/commands/bundle-api-spec/cli.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import yargs = require("yargs");
+import { bundleApiSpec } from ".";
+
+//
+// parse command line
+//
+
+const CODE_GROUP = "Code generation options:";
+
+const argv = yargs
+  .option("api-spec", {
+    alias: "i",
+    demandOption: true,
+    description: "Path to input OpenAPI spec file",
+    group: CODE_GROUP,
+    normalize: true,
+    string: true
+  })
+  .option("out-path", {
+    alias: "o",
+    demandOption: true,
+    description: "Output path of the spec file",
+    group: CODE_GROUP,
+    normalize: true,
+    string: true
+  })
+  .option("api-version", {
+    alias: "V",
+    description:
+      "Version of the api. If provided, override the version in the original spec file",
+    group: CODE_GROUP,
+    string: true
+  })
+  .help().argv;
+
+//
+// BUNDLE APIs
+//
+bundleApiSpec({
+  outPath: argv["out-path"],
+  specFilePath: argv["api-spec"],
+  version: argv["api-version"]
+}).then(
+  () => console.log("done"),
+  err => console.log(`Error: ${err}`)
+);

--- a/src/commands/bundle-api-spec/index.ts
+++ b/src/commands/bundle-api-spec/index.ts
@@ -1,0 +1,27 @@
+import { OpenAPIV2 } from "openapi-types";
+import * as SwaggerParser from "swagger-parser";
+import * as writeYamlFile from "write-yaml-file";
+
+export interface IBundleApiSpecOptions {
+  specFilePath: string | OpenAPIV2.Document;
+  outPath: string;
+  version?: string;
+}
+
+/**
+ * Takes an OpenAPI spec and writes a new one with only inner references
+ * @param param0
+ */
+export async function bundleApiSpec({
+  outPath,
+  specFilePath,
+  version
+}: IBundleApiSpecOptions) {
+  const bundled = await SwaggerParser.bundle(specFilePath);
+  // overwrite version
+  const edited = version
+    ? { ...bundled, info: { ...bundled.info, version } }
+    : bundled;
+
+  return writeYamlFile(outPath, edited);
+}

--- a/src/commands/gen-api-sdk/index.ts
+++ b/src/commands/gen-api-sdk/index.ts
@@ -4,6 +4,7 @@ import {
   createTemplateEnvironment,
   DEFAULT_TEMPLATE_DIR
 } from "../../lib/templating";
+import { bundleApiSpec } from "../bundle-api-spec";
 import { IGenerateSdkOptions } from "./types";
 
 const { render } = createTemplateEnvironment({
@@ -12,7 +13,7 @@ const { render } = createTemplateEnvironment({
 
 /**
  * Generate models as well as package scaffolding for a sdk that talks to a provided api spec
- * @param options 
+ * @param options
  */
 export async function generateSdk(options: IGenerateSdkOptions) {
   const files = await listTemplates();
@@ -25,6 +26,11 @@ export async function generateSdk(options: IGenerateSdkOptions) {
     generateClient: true,
     specFilePath: options.specFilePath,
     strictInterfaces: options.strictInterfaces
+  });
+  await bundleApiSpec({
+    outPath: `${options.outPath}/openapi.yaml`,
+    specFilePath: options.specFilePath,
+    version: options.version
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2366,6 +2366,11 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
+graceful-fs@^4.1.11:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
@@ -5649,6 +5654,15 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
+write-file-atomic@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
+
 write-file-atomic@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
@@ -5658,6 +5672,15 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+write-yaml-file@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/write-yaml-file/-/write-yaml-file-4.1.0.tgz#8a8af90b608b0e0a91d7b1fc67d1c5f06d8092f0"
+  integrity sha512-jN421OlwO/MN/EwAykk5ic8AL9QAycpKGaHKFBlcr3aQ6RUX8ZbrreOPUuhoYSxj/o30FhOQLSH36WYldAFrUw==
+  dependencies:
+    graceful-fs "^4.2.3"
+    js-yaml "^3.13.1"
+    write-file-atomic "^2.4.3"
 
 ws@^7.0.0:
   version "7.2.3"


### PR DESCRIPTION
A utility command to bundle all external references of an API spec into one single file. Plus: bundled spec file is included in the generated SDK.

### Usage
```sh
$ yarn bundle-api-spec -i /path/to/spec.yaml -o /path/to/bundled-spec.yaml
```
