### PR TITLE
[#174398656] Infer SDK package attributes from pacakge.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,27 +143,26 @@ const result = await clientWithGlobalToken.myOperation({
 
 ## gen-api-sdk
 Bundles a generated api models and clients into a node package ready to be published into a registry.
+The script is expected to be executed in the root of an application exposing an API, thus it infers package attributes from the expected `./package.json` file. Values can be still overridden by provinding the respective CLI argument. To avoid this behavior, use `--no-infer-attrs` or `-N`.
 
 ### Usage
 ```sh
 $ gen-api-sdk --help
 Package options:
-  --package-name, -n, --name          Name of the generated package
-                                                             [string] [required]
-  --package-version, -V               Version of the generated package
-                                                             [string] [required]
-  --package-description, -d, --desc   Description of the package
-                                                             [string] [required]
+  --no-infer-attr, -N                 Infer package attributes from a
+                                      package.json file present in the current
+                                      directory       [boolean] [default: false]
+  --package-name, -n, --name          Name of the generated package     [string]
+  --package-version, -V               Version of the generated package  [string]
+  --package-description, -d, --desc   Description of the package        [string]
+  --package-author, -a, --author      The author of the API exposed     [string]
+  --package-license, -L, --license    The license of the API Exposed    [string]
   --package-registry, -r, --registry  Url of the registry the package is
                                       published in                      [string]
   --package-access, -x, --access      Either 'public' or 'private', depending of
                                       the accessibility of the package in the
                                       registry
                                          [string] [choices: "public", "private"]
-  --package-author, -a, --author      The author of the API exposed
-                                                             [string] [required]
-  --package-license, -L, --license    The license of the API Exposed
-                                                             [string] [required]
 
 Code generation options:
   --api-spec, -i          Path to input OpenAPI spec file    [string] [required]
@@ -171,10 +170,12 @@ Code generation options:
                                                                  [default: true]
   --out-dir, -o           Output directory to store generated definition files
                                                              [string] [required]
-  --default-success-type  Default type for success responses (
+  --default-success-type  Default type for success responses (experimental,
                           default: 'undefined')  [string] [default: "undefined"]
-  --default-error-type    Default type for error responses (
+  --default-error-type    Default type for error responses (experimental,
                           default: 'undefined')  [string] [default: "undefined"]
+  --camel-cased           Generate camelCased properties name (default: false)
+                                                                [default: false]
 
 Options:
   --version  Show version number                                       [boolean]

--- a/src/__tests__/gen-api-sdk.test.ts
+++ b/src/__tests__/gen-api-sdk.test.ts
@@ -1,8 +1,15 @@
 import { renderAll } from "../commands/gen-api-sdk/index";
+import {
+  IGeneratorParams,
+  IPackageAttributes
+} from "../commands/gen-api-sdk/types";
 
 describe("gen-api-skd", () => {
   it("should render multiple templates", async () => {
-    const result = await renderAll(["tsconfig.json.njk", "index.ts.njk"], {});
+    const result = await renderAll(
+      ["tsconfig.json.njk", "index.ts.njk"],
+      {} as IPackageAttributes & IGeneratorParams
+    );
 
     expect(result).toEqual({
       "tsconfig.json.njk": expect.any(String),

--- a/src/commands/gen-api-sdk/cli.ts
+++ b/src/commands/gen-api-sdk/cli.ts
@@ -11,9 +11,17 @@ const PACKAGE_GROUP = "Package options:";
 const CODE_GROUP = "Code generation options:";
 
 const argv = yargs
+
+  .option("no-infer-attrs", {
+    alias: ["N"],
+    boolean: true,
+    description:
+      "Infer package attributes from a package.json file present in the current directory",
+    group: PACKAGE_GROUP,
+    default: false
+  })
   .option("package-name", {
     alias: ["n", "name"],
-    demandOption: true,
     description: "Name of the generated package",
     normalize: true,
     string: true,
@@ -21,18 +29,35 @@ const argv = yargs
   })
   .option("package-version", {
     alias: "V",
-    demandOption: true,
     description: "Version of the generated package",
     string: true,
     group: PACKAGE_GROUP
   })
   .option("package-description", {
     alias: ["d", "desc"],
-    demandOption: true,
     description: "Description of the package",
     string: true,
     group: PACKAGE_GROUP
   })
+  .option("package-author", {
+    alias: ["a", "author"],
+    description: "The author of the API exposed",
+    string: true,
+    group: PACKAGE_GROUP
+  })
+  .option("package-license", {
+    alias: ["L", "license"],
+    description: "The license of the API Exposed",
+    string: true,
+    group: PACKAGE_GROUP
+  })
+  .implies("no-infer-attrs", [
+    "package-name",
+    "package-version",
+    "package-description",
+    "package-author",
+    "package-license"
+  ])
   .option("package-registry", {
     alias: ["r", "registry"],
     description: "Url of the registry the package is published in",
@@ -48,20 +73,6 @@ const argv = yargs
     group: PACKAGE_GROUP
   })
   .implies("package-registry", "package-access")
-  .option("package-author", {
-    alias: ["a", "author"],
-    demandOption: true,
-    description: "The author of the API exposed",
-    string: true,
-    group: PACKAGE_GROUP
-  })
-  .option("package-license", {
-    alias: ["L", "license"],
-    demandOption: true,
-    description: "The license of the API Exposed",
-    string: true,
-    group: PACKAGE_GROUP
-  })
   .option("api-spec", {
     alias: "i",
     demandOption: true,
@@ -113,6 +124,7 @@ const argv = yargs
 //
 generateSdk({
   camelCasedPropNames: argv["camel-cased"],
+  inferAttr: !argv["no-infer-attr"],
   name: argv["package-name"],
   version: argv["package-version"],
   description: argv["package-description"],

--- a/src/commands/gen-api-sdk/index.ts
+++ b/src/commands/gen-api-sdk/index.ts
@@ -5,7 +5,12 @@ import {
   DEFAULT_TEMPLATE_DIR
 } from "../../lib/templating";
 import { bundleApiSpec } from "../bundle-api-spec";
-import { IGenerateSdkOptions } from "./types";
+import {
+  IGenerateSdkOptions,
+  IGeneratorParams,
+  IPackageAttributes,
+  IRegistryAttributes
+} from "./types";
 
 const { render } = createTemplateEnvironment({
   templateDir: `${DEFAULT_TEMPLATE_DIR}/sdk`
@@ -17,7 +22,16 @@ const { render } = createTemplateEnvironment({
  */
 export async function generateSdk(options: IGenerateSdkOptions) {
   const files = await listTemplates();
-  const renderedFiles = await renderAll(files, options);
+
+  const { inferAttr, ...params } = options;
+
+  const templateParams: IPackageAttributes &
+    IRegistryAttributes &
+    IGeneratorParams = inferAttr
+    ? mergeParams(await inferAttributesFromPackage(), params)
+    : params;
+
+  const renderedFiles = await renderAll(files, templateParams);
   await writeAllGeneratedCodeFiles(options.outPath, renderedFiles);
   await generateApi({
     camelCasedPropNames: options.camelCasedPropNames,
@@ -35,6 +49,39 @@ export async function generateSdk(options: IGenerateSdkOptions) {
   });
 }
 
+async function inferAttributesFromPackage(): Promise<
+  IPackageAttributes & IRegistryAttributes
+> {
+  const pkg = await fs
+    .readFile(`${process.cwd()}/package.json`)
+    .then(String)
+    .then(JSON.parse)
+    .catch(ex => {
+      throw new Error(
+        `Failed to read package.json from the current directory: ${ex}`
+      );
+    });
+  return {
+    name: `${pkg.name}-sdk`,
+    version: pkg.version,
+    description: `Generated SDK for ${pkg.name}. ${pkg.description}`,
+    author: pkg.author,
+    license: pkg.license,
+    registry: pkg.publishConfig?.registry,
+    access: pkg.publishConfig?.access
+  };
+}
+
+function mergeParams<A extends object, B extends object>(a: A, b: B): any {
+  return Object.keys({ ...a, ...b }).reduce(
+    (p: any, k: string) => ({
+      ...p,
+      [k]: b[k as keyof B] || a[k as keyof A]
+    }),
+    {}
+  );
+}
+
 async function listTemplates(): Promise<string[]> {
   return ["package.json.njk", "tsconfig.json.njk", "index.ts.njk"];
 }
@@ -45,7 +92,7 @@ async function listTemplates(): Promise<string[]> {
  */
 export async function renderAll(
   files: ReadonlyArray<string>,
-  options?: object
+  options: IPackageAttributes & IRegistryAttributes & IGeneratorParams
 ): Promise<Record<string, string>> {
   const allContent = await Promise.all(
     files.map(file => render(file, options))

--- a/src/commands/gen-api-sdk/index.ts
+++ b/src/commands/gen-api-sdk/index.ts
@@ -21,9 +21,9 @@ const { render } = createTemplateEnvironment({
  * @param options
  */
 export async function generateSdk(options: IGenerateSdkOptions) {
-  const files = await listTemplates();
-
   const { inferAttr, ...params } = options;
+
+  await fs.ensureDir(params.outPath);
 
   const templateParams: IPackageAttributes &
     IRegistryAttributes &
@@ -31,7 +31,7 @@ export async function generateSdk(options: IGenerateSdkOptions) {
     ? mergeParams(await inferAttributesFromPackage(), params)
     : params;
 
-  const renderedFiles = await renderAll(files, templateParams);
+  const renderedFiles = await renderAll(listTemplates(), templateParams);
   await writeAllGeneratedCodeFiles(options.outPath, renderedFiles);
   await generateApi({
     camelCasedPropNames: options.camelCasedPropNames,
@@ -74,7 +74,7 @@ async function inferAttributesFromPackage(): Promise<
 
 function mergeParams<A extends object, B extends object>(a: A, b: B): any {
   return Object.keys({ ...a, ...b }).reduce(
-    (p: any, k: string) => ({
+    (p: object, k: string) => ({
       ...p,
       [k]: b[k as keyof B] || a[k as keyof A]
     }),
@@ -82,7 +82,7 @@ function mergeParams<A extends object, B extends object>(a: A, b: B): any {
   );
 }
 
-async function listTemplates(): Promise<string[]> {
+function listTemplates(): string[] {
   return ["package.json.njk", "tsconfig.json.njk", "index.ts.njk"];
 }
 

--- a/src/commands/gen-api-sdk/types.ts
+++ b/src/commands/gen-api-sdk/types.ts
@@ -1,13 +1,11 @@
 import { OpenAPIV2 } from "openapi-types";
 
-export interface IGenerateSdkOptions {
-  name: string;
-  version: string;
-  description: string;
-  author: string;
-  license: string;
+export interface IRegistryAttributes {
   registry?: string;
   access?: string;
+}
+
+export interface IGeneratorParams {
   specFilePath: string | OpenAPIV2.Document;
   outPath: string;
   strictInterfaces?: boolean;
@@ -15,3 +13,22 @@ export interface IGenerateSdkOptions {
   defaultErrorType?: string;
   camelCasedPropNames: boolean;
 }
+
+export interface IPackageAttributes {
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  license: string;
+}
+
+export type IGenerateSdkOptions = IGeneratorParams &
+  IRegistryAttributes &
+  (
+    | ({
+        inferAttr: false;
+      } & IPackageAttributes)
+    | ({
+        inferAttr: true;
+      } & Partial<IPackageAttributes>)
+  );


### PR DESCRIPTION
Use the `package.json` of the parent application to infer SDK attributes automatically. See [here](https://github.com/pagopa/io-utils/compare/release/5.0.0...174398656-inherit-from-packagejson?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R146) for documentation.