### PR TITLE
[#174993325] Handle upper bound limit on ranged numbers, integers and strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Generated code is slightly different from `v4` as it implements some bug fixes t
 * When using `gen-api-models` command, `--request-types` flag must be used explicitly in order to have `requestTypes` file generated.
 * Parameters that has a schema reference (like [this](https://github.com/pagopa/io-utils/blob/491d927ff263863bda9038fffa26442050b788e7/__mocks__/api.yaml#L87)) now use the `name` attribute as the parameter name. It used to be the lower-cased reference's name instead.
 * The script creates the destination folder automatically, there is no need to `mkdir` anymore.
-* The change of [#182] has been reverted, `WithinRangeInteger<L,H>` now defines a set `[L,H]` (in 4.3.0 we used to add `1` to `H`, now it's not longer needed). 
+* Both ranged number and integers now correctly include upper bound values. This is achieved without using the _add 1_ trick implemented in [#182], which is reverted. Breaking changes may arise in target application if values are assigned to variables of type `WithinRangeInteger` or `WithinRangeNumber`. See [#205].
 #### from 4.0.0 to 4.3.0
 * Attributes with `type: string` and `format: date` used to result in a `String` definition, while now produce `Date`. [#184](https://github.com/pagopa/io-utils/pull/184)
 * Allow camel-cased prop names. [#183](https://github.com/pagopa/io-utils/pull/183)

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Generated code is slightly different from `v4` as it implements some bug fixes t
 * When using `gen-api-models` command, `--request-types` flag must be used explicitly in order to have `requestTypes` file generated.
 * Parameters that has a schema reference (like [this](https://github.com/pagopa/io-utils/blob/491d927ff263863bda9038fffa26442050b788e7/__mocks__/api.yaml#L87)) now use the `name` attribute as the parameter name. It used to be the lower-cased reference's name instead.
 * The script creates the destination folder automatically, there is no need to `mkdir` anymore.
+* The change of [#182] has been reverted, `WithinRangeInteger<L,H>` now defines a set `[L,H]` (in 4.3.0 we used to add `1` to `H`, now it's not longer needed). 
 #### from 4.0.0 to 4.3.0
 * Attributes with `type: string` and `format: date` used to result in a `String` definition, while now produce `Date`. [#184](https://github.com/pagopa/io-utils/pull/184)
 * Allow camel-cased prop names. [#183](https://github.com/pagopa/io-utils/pull/183)

--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -181,7 +181,7 @@ definitions:
   WithinRangeStringTest:
     title: WithinRangeStringTest
     type: string
-    minLength: 10
+    minLength: 8
     maxLength: 10
   WithinRangeNumberTest:
     title: WithinRangeNumberTest

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -4,7 +4,10 @@ import config from "../../config";
 import * as leaked from "leaked-handles";
 leaked.set({ debugSockets: true });
 
-import { IWithinRangeIntegerTag, IWithinRangeNumberTag } from "italia-ts-commons/lib/numbers";
+import {
+  IWithinRangeIntegerTag,
+  IWithinRangeNumberTag
+} from "italia-ts-commons/lib/numbers";
 import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeIntegerTest";
 import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
 
@@ -13,122 +16,127 @@ const { generatedFilesDir, isSpecEnabled } = config.specs.testapi;
 // if there's no need for this suite in this particular run, just skip it
 const describeSuite = isSpecEnabled ? describe : describe.skip;
 
-describeSuite("Decoders generated from Test API spec defintions", () => {
-  const loadModule = (name: string) =>
-    import(`${generatedFilesDir}/${name}.ts`).then(mod => {
-      if (!mod) {
-        fail(`Cannot load module ${generatedFilesDir}/${name}.ts`);
-      }
-      return mod;
-    });
-
-  describe("FiscalCode definition", () => {
-    it("should generate FiscalCode decoder", async () => {
-      const { FiscalCode } = await loadModule("FiscalCode");
-      expect(FiscalCode).toBeDefined();
-    });
-
-    it.each`
-      title                                | example               | expected
-      ${"should fail decoding empty"}      | ${""}                 | ${false}
-      ${"should decode valid cf"}          | ${"RSSMRA80A01F205X"} | ${true}
-      ${"should fail decoding invalid cf"} | ${"INVALIDCFFORMAT"}  | ${false}
-    `("$title", async ({ example, expected }) => {
-      const { FiscalCode } = await loadModule("FiscalCode");
-      const result = FiscalCode.decode(example).isRight();
-      expect(result).toEqual(expected);
-    });
+const loadModule = (name: string) =>
+  import(`${generatedFilesDir}/${name}.ts`).then(mod => {
+    if (!mod) {
+      fail(`Cannot load module ${generatedFilesDir}/${name}.ts`);
+    }
+    return mod;
   });
 
-  describe("Profile defintion", () => {
-    it("should generate Profile decoder", async () => {
-      const { Profile } = await loadModule("Profile");
-      expect(Profile).toBeDefined();
-    });
-
-    const basicProfile = {
-      family_name: "Rossi",
-      fiscal_code: "RSSMRA80A01F205X",
-      has_profile: true,
-      is_email_set: false,
-      name: "Mario",
-      version: 123
-    };
-    const completeProfile = {
-      family_name: "Rossi",
-      fiscal_code: "RSSMRA80A01F205X",
-      has_profile: true,
-      is_email_set: false,
-      name: "Mario",
-      version: 123,
-      email: "fake@email.com"
-    };
-    const profileWithPayload = {
-      family_name: "Rossi",
-      fiscal_code: "RSSMRA80A01F205X",
-      has_profile: true,
-      is_email_set: false,
-      name: "Mario",
-      version: 123,
-      payload: { foo: "bar" }
-    };
-
-    it.each`
-      title                                   | example               | expected
-      ${"should fail decoding empty"}         | ${""}                 | ${false}
-      ${"should fail decoding non-object"}    | ${"value"}            | ${false}
-      ${"should decode basic profile"}        | ${basicProfile}       | ${true}
-      ${"should decode complete profile"}     | ${completeProfile}    | ${true}
-      ${"should decode profile with payload"} | ${profileWithPayload} | ${true}
-    `("$title", async ({ example, expected }) => {
-      const { Profile } = await loadModule("Profile");
-      const result = Profile.decode(example).isRight();
-      expect(result).toEqual(expected);
-    });
+describe("FiscalCode definition", () => {
+  it("should generate FiscalCode decoder", async () => {
+    const { FiscalCode } = await loadModule("FiscalCode");
+    expect(FiscalCode).toBeDefined();
   });
 
-  
+  it.each`
+    title                                | example               | expected
+    ${"should fail decoding empty"}      | ${""}                 | ${false}
+    ${"should decode valid cf"}          | ${"RSSMRA80A01F205X"} | ${true}
+    ${"should fail decoding invalid cf"} | ${"INVALIDCFFORMAT"}  | ${false}
+  `("$title", async ({ example, expected }) => {
+    const { FiscalCode } = await loadModule("FiscalCode");
+    const result = FiscalCode.decode(example).isRight();
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("Profile defintion", () => {
+  it("should generate Profile decoder", async () => {
+    const { Profile } = await loadModule("Profile");
+    expect(Profile).toBeDefined();
+  });
+
+  const basicProfile = {
+    family_name: "Rossi",
+    fiscal_code: "RSSMRA80A01F205X",
+    has_profile: true,
+    is_email_set: false,
+    name: "Mario",
+    version: 123
+  };
+  const completeProfile = {
+    family_name: "Rossi",
+    fiscal_code: "RSSMRA80A01F205X",
+    has_profile: true,
+    is_email_set: false,
+    name: "Mario",
+    version: 123,
+    email: "fake@email.com"
+  };
+  const profileWithPayload = {
+    family_name: "Rossi",
+    fiscal_code: "RSSMRA80A01F205X",
+    has_profile: true,
+    is_email_set: false,
+    name: "Mario",
+    version: 123,
+    payload: { foo: "bar" }
+  };
+
+  it.each`
+    title                                   | example               | expected
+    ${"should fail decoding empty"}         | ${""}                 | ${false}
+    ${"should fail decoding non-object"}    | ${"value"}            | ${false}
+    ${"should decode basic profile"}        | ${basicProfile}       | ${true}
+    ${"should decode complete profile"}     | ${completeProfile}    | ${true}
+    ${"should decode profile with payload"} | ${profileWithPayload} | ${true}
+  `("$title", async ({ example, expected }) => {
+    const { Profile } = await loadModule("Profile");
+    const result = Profile.decode(example).isRight();
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("WithinRangeIntegerTest defintion", () => {
   //WithinRangeIntegerTest is defined min=0 max=10
-   it.each`
-     value        | expected
-     ${0}         | ${true}
-     ${-1}        | ${false}
-     ${5}         | ${true}
-     ${10}        | ${true}
-     ${11}        | ${false}
-     ${100}       | ${false}
-     ${undefined} | ${false}
-   `(
-     "should decode $value with WithinRangeIntegerTest",
-     ({ value, expected }) => {
-       const result = WithinRangeIntegerTest.decode(value);
-       expect(result.isRight()).toEqual(expected);
-       if (result.isRight()) {
-         // check definition
-         const _: IWithinRangeIntegerTag<0, 11> = result.value;
-       }
-     }
-   );
+  it.each`
+    value        | expected
+    ${0}         | ${true /* lower bound */}
+    ${-1}        | ${false}
+    ${5}         | ${true}
+    ${9.9999}    | ${false /* not an integer */}
+    ${10}        | ${true /* upper bound */}
+    ${10.0001}   | ${false /* not an integer */}
+    ${11}        | ${false}
+    ${100}       | ${false}
+    ${undefined} | ${false}
+  `(
+    "should decode $value with WithinRangeIntegerTest",
+    ({ value, expected }) => {
+      const result = WithinRangeIntegerTest.decode(value);
+      expect(result.isRight()).toEqual(expected);
+      if (result.isRight()) {
+        // check definition
+        const _: IWithinRangeIntegerTag<0, 11> = result.value;
+      }
+    }
+  );
+});
 
-   //WithinRangeNumberTest is defined min=0 max=10
-   it.each`
-     value  | expected
-     ${0}   | ${true}
-     ${-1}  | ${false}
-     ${5}   | ${true}
-     ${10}  | ${true}
-     ${11}  | ${false}
-     ${100} | ${false}
-     ${undefined} | ${false}
-   `(
-     "should decode $value with WithinRangeNumberTest",
-     ({ value, expected }) => {
-       const result = WithinRangeNumberTest.decode(value);
-       expect(result.isRight()).toEqual(expected);
-       if (result.isRight()) {
-         // check definition
-         const _: IWithinRangeNumberTag<0, 10> = result.value;
-       }
-     }
-   );
+describe("WithinRangeNumberTest defintion", () => {
+  //WithinRangeNumberTest is defined min=0 max=10
+  it.each`
+    value        | expected
+    ${0}         | ${true /* lower bound */}
+    ${-1}        | ${false}
+    ${5}         | ${true}
+    ${9.9999999} | ${true}
+    ${10}        | ${true /* upper bound */}
+    ${10.000001} | ${false}
+    ${11}        | ${false}
+    ${100}       | ${false}
+    ${undefined} | ${false}
+  `(
+    "should decode $value with WithinRangeNumberTest",
+    ({ value, expected }) => {
+      const result = WithinRangeNumberTest.decode(value);
+      expect(result.isRight()).toEqual(expected);
+      if (result.isRight()) {
+        // check definition
+        const _: IWithinRangeNumberTag<0, 10> = result.value;
+      }
+    }
+  );
 });

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -10,6 +10,8 @@ import {
 } from "italia-ts-commons/lib/numbers";
 import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeIntegerTest";
 import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
+import { WithinRangeStringTest } from "../../generated/testapi/WithinRangeStringTest";
+import { WithinRangeString } from "italia-ts-commons/lib/strings";
 
 const { generatedFilesDir, isSpecEnabled } = config.specs.testapi;
 
@@ -90,7 +92,7 @@ describe("Profile defintion", () => {
 });
 
 describe("WithinRangeIntegerTest defintion", () => {
-  //WithinRangeIntegerTest is defined min=0 max=10
+  //WithinRangeIntegerTest is defined min=0 max=10 in the spec
   it.each`
     value        | expected
     ${0}         | ${true /* lower bound */}
@@ -108,7 +110,7 @@ describe("WithinRangeIntegerTest defintion", () => {
       const result = WithinRangeIntegerTest.decode(value);
       expect(result.isRight()).toEqual(expected);
       if (result.isRight()) {
-        // check definition
+        // check type definition
         const _: IWithinRangeIntegerTag<0, 11> = result.value;
       }
     }
@@ -116,7 +118,7 @@ describe("WithinRangeIntegerTest defintion", () => {
 });
 
 describe("WithinRangeNumberTest defintion", () => {
-  //WithinRangeNumberTest is defined min=0 max=10
+  //WithinRangeNumberTest is defined min=0 max=10 in the spec
   it.each`
     value        | expected
     ${0}         | ${true /* lower bound */}
@@ -134,8 +136,31 @@ describe("WithinRangeNumberTest defintion", () => {
       const result = WithinRangeNumberTest.decode(value);
       expect(result.isRight()).toEqual(expected);
       if (result.isRight()) {
-        // check definition
-        const _: IWithinRangeNumberTag<0, 10> = result.value;
+        // check type definition
+        const _: IWithinRangeNumberTag<0, 11> = result.value;
+      }
+    }
+  );
+});
+
+describe("WithinRangeStringTest defintion", () => {
+  //WithinRangeStringTest is defined min=8 max=10 in the spec
+  it.each`
+    value             | expected
+    ${"a".repeat(7)}  | ${false}
+    ${"a".repeat(8)}  | ${true /* lower bound */}
+    ${"a".repeat(9)}  | ${true}
+    ${"a".repeat(10)} | ${true /* upper bound */}
+    ${"a".repeat(11)} | ${false}
+    ${undefined}      | ${false}
+  `(
+    "should decode $value with WithinRangeStringTest",
+    ({ value, expected }) => {
+      const result = WithinRangeStringTest.decode(value);
+      expect(result.isRight()).toEqual(expected);
+      if (result.isRight()) {
+        // check type definition
+        const _: WithinRangeString<8, 11> = result.value;
       }
     }
   );

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -4,6 +4,10 @@ import config from "../../config";
 import * as leaked from "leaked-handles";
 leaked.set({ debugSockets: true });
 
+import { IWithinRangeIntegerTag, IWithinRangeNumberTag } from "italia-ts-commons/lib/numbers";
+import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeIntegerTest";
+import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
+
 const { generatedFilesDir, isSpecEnabled } = config.specs.testapi;
 
 // if there's no need for this suite in this particular run, just skip it
@@ -82,4 +86,49 @@ describeSuite("Decoders generated from Test API spec defintions", () => {
       expect(result).toEqual(expected);
     });
   });
+
+  
+  //WithinRangeIntegerTest is defined min=0 max=10
+   it.each`
+     value        | expected
+     ${0}         | ${true}
+     ${-1}        | ${false}
+     ${5}         | ${true}
+     ${10}        | ${true}
+     ${11}        | ${false}
+     ${100}       | ${false}
+     ${undefined} | ${false}
+   `(
+     "should decode $value with WithinRangeIntegerTest",
+     ({ value, expected }) => {
+       const result = WithinRangeIntegerTest.decode(value);
+       expect(result.isRight()).toEqual(expected);
+       if (result.isRight()) {
+         // check definition
+         const _: IWithinRangeIntegerTag<0, 11> = result.value;
+       }
+     }
+   );
+
+   //WithinRangeNumberTest is defined min=0 max=10
+   it.each`
+     value  | expected
+     ${0}   | ${true}
+     ${-1}  | ${false}
+     ${5}   | ${true}
+     ${10}  | ${true}
+     ${11}  | ${false}
+     ${100} | ${false}
+     ${undefined} | ${false}
+   `(
+     "should decode $value with WithinRangeNumberTest",
+     ({ value, expected }) => {
+       const result = WithinRangeNumberTest.decode(value);
+       expect(result.isRight()).toEqual(expected);
+       if (result.isRight()) {
+         // check definition
+         const _: IWithinRangeNumberTag<0, 10> = result.value;
+       }
+     }
+   );
 });

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -12,6 +12,7 @@ import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeInteg
 import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
 import { WithinRangeStringTest } from "../../generated/testapi/WithinRangeStringTest";
 import { WithinRangeString } from "italia-ts-commons/lib/strings";
+import { readableReport } from "italia-ts-commons/lib/reporters";
 
 const { generatedFilesDir, isSpecEnabled } = config.specs.testapi;
 
@@ -111,7 +112,7 @@ describe("WithinRangeIntegerTest defintion", () => {
       expect(result.isRight()).toEqual(expected);
       if (result.isRight()) {
         // check type definition
-        const _: IWithinRangeIntegerTag<0, 11> = result.value;
+        const _: IWithinRangeIntegerTag<0, 10> = result.value;
       }
     }
   );
@@ -137,10 +138,22 @@ describe("WithinRangeNumberTest defintion", () => {
       expect(result.isRight()).toEqual(expected);
       if (result.isRight()) {
         // check type definition
-        const _: IWithinRangeNumberTag<0, 11> = result.value;
+        const _: IWithinRangeNumberTag<0, 10> = result.value;
+        const __: 10 = result.value;
       }
     }
   );
+
+  it("should have correct ts types", () => {
+    // value is actually "any"
+    const value1: WithinRangeNumberTest = WithinRangeNumberTest.decode(10).getOrElseL(err => {
+      throw new Error(readableReport(err))
+    });
+    // should this be ok? value1 can be 10 and it's not in [0, 10)
+    const asRangedValue: IWithinRangeNumberTag<0, 10> = value1;
+    // should this be ok? value1 can be in [0, 10) and it's not 10
+    const asRangedValue2: 10 = value1;
+  })
 });
 
 describe("WithinRangeStringTest defintion", () => {

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -110,10 +110,6 @@ describe("WithinRangeIntegerTest defintion", () => {
     ({ value, expected }) => {
       const result = WithinRangeIntegerTest.decode(value);
       expect(result.isRight()).toEqual(expected);
-      if (result.isRight()) {
-        // check type definition
-        const _: IWithinRangeIntegerTag<0, 10> = result.value;
-      }
     }
   );
 });
@@ -136,24 +132,21 @@ describe("WithinRangeNumberTest defintion", () => {
     ({ value, expected }) => {
       const result = WithinRangeNumberTest.decode(value);
       expect(result.isRight()).toEqual(expected);
-      if (result.isRight()) {
-        // check type definition
-        const _: IWithinRangeNumberTag<0, 10> = result.value;
-        const __: 10 = result.value;
-      }
     }
   );
 
-  it("should have correct ts types", () => {
+/*   it("should have correct ts types", () => {
     // value is actually "any"
     const value1: WithinRangeNumberTest = WithinRangeNumberTest.decode(10).getOrElseL(err => {
       throw new Error(readableReport(err))
     });
     // should this be ok? value1 can be 10 and it's not in [0, 10)
     const asRangedValue: IWithinRangeNumberTag<0, 10> = value1;
+    const asRangedValue3: IWithinRangeNumberTag<0, 10> = value1;
     // should this be ok? value1 can be in [0, 10) and it's not 10
     const asRangedValue2: 10 = value1;
-  })
+    const asRangedValue5: WithinRangeNumberTest = 10;
+  }) */
 });
 
 describe("WithinRangeStringTest defintion", () => {
@@ -171,10 +164,6 @@ describe("WithinRangeStringTest defintion", () => {
     ({ value, expected }) => {
       const result = WithinRangeStringTest.decode(value);
       expect(result.isRight()).toEqual(expected);
-      if (result.isRight()) {
-        // check type definition
-        const _: WithinRangeString<8, 11> = result.value;
-      }
     }
   );
 });

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -454,12 +454,15 @@ exports[`gen-api-models should handle WithinRangeIntegers: within-range-integer 
  */
 /* tslint:disable */
 
-import { WithinRangeInteger } from \\"italia-ts-commons/lib/numbers\\";
+import {
+  IWithinRangeIntegerTag,
+  WithinRangeInteger
+} from \\"italia-ts-commons/lib/numbers\\";
 import * as t from \\"io-ts\\";
 
 export type WithinRangeIntegerTest = t.TypeOf<typeof WithinRangeIntegerTest>;
 export const WithinRangeIntegerTest = t.union([
-  WithinRangeInteger(0, 10),
+  WithinRangeInteger<0, 10, IWithinRangeIntegerTag<0, 10>>(0, 10),
   t.literal(10)
 ]);
 "
@@ -472,12 +475,15 @@ exports[`gen-api-models should handle WithinRangeNumbers: within-range-numbers 1
  */
 /* tslint:disable */
 
-import { WithinRangeNumber } from \\"italia-ts-commons/lib/numbers\\";
+import {
+  IWithinRangeNumberTag,
+  WithinRangeNumber
+} from \\"italia-ts-commons/lib/numbers\\";
 import * as t from \\"io-ts\\";
 
 export type WithinRangeNumberTest = t.TypeOf<typeof WithinRangeNumberTest>;
 export const WithinRangeNumberTest = t.union([
-  WithinRangeNumber(0, 10),
+  WithinRangeNumber<0, 10, IWithinRangeNumberTag<0, 10>>(0, 10),
   t.literal(10)
 ]);
 "

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -458,7 +458,10 @@ import { WithinRangeInteger } from \\"italia-ts-commons/lib/numbers\\";
 import * as t from \\"io-ts\\";
 
 export type WithinRangeIntegerTest = t.TypeOf<typeof WithinRangeIntegerTest>;
-export const WithinRangeIntegerTest = WithinRangeInteger(0, 11);
+export const WithinRangeIntegerTest = t.union([
+  WithinRangeInteger(0, 10),
+  t.literal(10)
+]);
 "
 `;
 
@@ -473,7 +476,10 @@ import { WithinRangeNumber } from \\"italia-ts-commons/lib/numbers\\";
 import * as t from \\"io-ts\\";
 
 export type WithinRangeNumberTest = t.TypeOf<typeof WithinRangeNumberTest>;
-export const WithinRangeNumberTest = WithinRangeNumber(0, 11);
+export const WithinRangeNumberTest = t.union([
+  WithinRangeNumber(0, 10),
+  t.literal(10)
+]);
 "
 `;
 

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -473,7 +473,7 @@ import { WithinRangeNumber } from \\"italia-ts-commons/lib/numbers\\";
 import * as t from \\"io-ts\\";
 
 export type WithinRangeNumberTest = t.TypeOf<typeof WithinRangeNumberTest>;
-export const WithinRangeNumberTest = WithinRangeNumber(0, 10);
+export const WithinRangeNumberTest = WithinRangeNumber(0, 11);
 "
 `;
 
@@ -488,7 +488,7 @@ import { WithinRangeString } from \\"italia-ts-commons/lib/strings\\";
 import * as t from \\"io-ts\\";
 
 export type WithinRangeStringTest = t.TypeOf<typeof WithinRangeStringTest>;
-export const WithinRangeStringTest = WithinRangeString(10, 11);
+export const WithinRangeStringTest = WithinRangeString(8, 11);
 "
 `;
 

--- a/src/commands/gen-api-models/__tests__/index.test.ts
+++ b/src/commands/gen-api-models/__tests__/index.test.ts
@@ -87,7 +87,7 @@ describe("gen-api-models", () => {
       definition,
       false
     );
-    expect(code).toContain("WithinRangeString(10, 11)");
+    expect(code).toContain("WithinRangeString(8, 11)");
     expect(code).toMatchSnapshot("within-range-strings");
   });
 

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -70,8 +70,11 @@
  #}
 {% macro defineNumber(definitionName, definition, inline = false) -%}
   {% if definition.minimum != undefined and definition.maximum != undefined %}
-    {{- 'import { WithinRangeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
-    {% set typedef %}t.union([WithinRangeNumber({{ definition.minimum }}, {{ definition.maximum }}), t.literal({{ definition.maximum }})]){% endset %}
+    {{- 'import { IWithinRangeNumberTag, WithinRangeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
+    {% set typedef %}t.union([
+      WithinRangeNumber<{{ definition.minimum }}, {{ definition.maximum }}, IWithinRangeNumberTag<{{ definition.minimum }}, {{ definition.maximum }}>>({{ definition.minimum }}, {{ definition.maximum }}),
+      t.literal({{ definition.maximum }})
+    ]){% endset %}
   {% elif definition.minimum == "0" %}
     {{- 'import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
     {% set typedef %}NonNegativeNumber{% endset %}
@@ -86,8 +89,11 @@
  #}
 {% macro defineInteger(definitionName, definition, inline = false) -%}
   {% if definition.minimum != undefined and definition.maximum != undefined %}
-    {{- 'import { WithinRangeInteger } from "italia-ts-commons/lib/numbers";' | addImport -}}
-    {% set typedef %}t.union([WithinRangeInteger({{ definition.minimum }}, {{ definition.maximum }}), t.literal({{ definition.maximum }})]){% endset %}
+    {{- 'import { IWithinRangeIntegerTag, WithinRangeInteger } from "italia-ts-commons/lib/numbers";' | addImport -}}
+    {% set typedef %}t.union([
+      WithinRangeInteger<{{ definition.minimum }}, {{ definition.maximum }}, IWithinRangeIntegerTag<{{ definition.minimum }}, {{ definition.maximum }}>>({{ definition.minimum }}, {{ definition.maximum }}),
+      t.literal({{ definition.maximum }})
+    ]){% endset %}
   {% elif definition.minimum == "0" %}
     {{- 'import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";' | addImport -}}
     {% set typedef %}NonNegativeInteger{% endset %}

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -71,7 +71,7 @@
 {% macro defineNumber(definitionName, definition, inline = false) -%}
   {% if definition.minimum != undefined and definition.maximum != undefined %}
     {{- 'import { WithinRangeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
-    {% set typedef %}WithinRangeNumber({{ definition.minimum }}, {{ definition.maximum }}){% endset %}
+    {% set typedef %}WithinRangeNumber({{ definition.minimum }}, {{ definition.maximum + 1 }}){% endset %}
   {% elif definition.minimum == "0" %}
     {{- 'import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
     {% set typedef %}NonNegativeNumber{% endset %}

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -71,7 +71,7 @@
 {% macro defineNumber(definitionName, definition, inline = false) -%}
   {% if definition.minimum != undefined and definition.maximum != undefined %}
     {{- 'import { WithinRangeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
-    {% set typedef %}WithinRangeNumber({{ definition.minimum }}, {{ definition.maximum + 1 }}){% endset %}
+    {% set typedef %}t.union([WithinRangeNumber({{ definition.minimum }}, {{ definition.maximum }}), t.literal({{ definition.maximum }})]){% endset %}
   {% elif definition.minimum == "0" %}
     {{- 'import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
     {% set typedef %}NonNegativeNumber{% endset %}
@@ -87,7 +87,7 @@
 {% macro defineInteger(definitionName, definition, inline = false) -%}
   {% if definition.minimum != undefined and definition.maximum != undefined %}
     {{- 'import { WithinRangeInteger } from "italia-ts-commons/lib/numbers";' | addImport -}}
-    {% set typedef %}WithinRangeInteger({{ definition.minimum }}, {{ definition.maximum + 1 }}){% endset %}
+    {% set typedef %}t.union([WithinRangeInteger({{ definition.minimum }}, {{ definition.maximum }}), t.literal({{ definition.maximum }})]){% endset %}
   {% elif definition.minimum == "0" %}
     {{- 'import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";' | addImport -}}
     {% set typedef %}NonNegativeInteger{% endset %}


### PR DESCRIPTION
In #182 we fixed generated `WithinRangeInteger`s by including the max number into the set of allowed numbers. It has been reported this may not work, thus I wrote some tests which are passing, instead. 

Incidentally, I'm testing the very same behaviour against `WithinRangeNumber` but I'm getting failures this time. In the end we have now:
* `WithinRangeInteger` to be `[min, max]`
* `WithinRangeNumber` to be `[min, max)`

I wonder if it is the intended behaviour, or instead we need to fix the off-by-one problem in `WithinRangeNumber` as well.