### PR TITLE
[#175017856] Handle exclusiveMaximum and exclusiveMinimum 

### DIFF
--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -214,24 +214,43 @@ definitions:
     minimum: 0
     maximum: 10
   WithinRangeExclusiveMinimumNumberTest:
-    title: WithinRangeNumberTest
+    title: WithinRangeExclusiveMinimumNumberTest
     type: number
     minimum: 0
     exclusiveMinimum: true
     maximum: 10
   WithinRangeExclusiveMaximumNumberTest:
-    title: WithinRangeNumberTest
+    title: WithinRangeExclusiveMaximumNumberTest
     type: number
     minimum: 0
     maximum: 10
     exclusiveMaximum: true    
-  WithinRangeExclusiveMaxMaxNumberTest:
-    title: WithinRangeNumberTest
+  WithinRangeExclusiveMinMaxNumberTest:
+    title: WithinRangeExclusiveMinMaxNumberTest
     type: number
     minimum: 0
     exclusiveMinimum: true
     maximum: 10
+    exclusiveMaximum: true
+  WithinRangeExclusiveMinimumIntegerTest:
+    title: WithinRangeExclusiveMinimumIntegerTest
+    type: integer
+    minimum: 0
+    exclusiveMinimum: true
+    maximum: 10
+  WithinRangeExclusiveMaximumIntegerTest:
+    title: WithinRangeExclusiveMaximumIntegerTest
+    type: integer
+    minimum: 0
+    maximum: 10
     exclusiveMaximum: true    
+  WithinRangeExclusiveMinMaxIntegerTest:
+    title: WithinRangeExclusiveMinMaxIntegerTest
+    type: number
+    minimum: 0
+    exclusiveMinimum: true
+    maximum: 10
+    exclusiveMaximum: true      
   InlinePropertyTest:
     type: object
     properties:

--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -213,6 +213,25 @@ definitions:
     type: number
     minimum: 0
     maximum: 10
+  WithinRangeExclusiveMinimumNumberTest:
+    title: WithinRangeNumberTest
+    type: number
+    minimum: 0
+    exclusiveMinimum: true
+    maximum: 10
+  WithinRangeExclusiveMaximumNumberTest:
+    title: WithinRangeNumberTest
+    type: number
+    minimum: 0
+    maximum: 10
+    exclusiveMaximum: true    
+  WithinRangeExclusiveMaxMaxNumberTest:
+    title: WithinRangeNumberTest
+    type: number
+    minimum: 0
+    exclusiveMinimum: true
+    maximum: 10
+    exclusiveMaximum: true    
   InlinePropertyTest:
     type: object
     properties:

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -8,6 +8,8 @@ import {
   IWithinRangeIntegerTag,
   IWithinRangeNumberTag
 } from "italia-ts-commons/lib/numbers";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+import { WithinRangeString } from "italia-ts-commons/lib/strings";
 import { WithinRangeExclusiveMaximumIntegerTest } from "../../generated/testapi/WithinRangeExclusiveMaximumIntegerTest";
 import { WithinRangeExclusiveMaximumNumberTest } from "../../generated/testapi/WithinRangeExclusiveMaximumNumberTest";
 import { WithinRangeExclusiveMinimumIntegerTest } from "../../generated/testapi/WithinRangeExclusiveMinimumIntegerTest";
@@ -15,8 +17,6 @@ import { WithinRangeExclusiveMinimumNumberTest } from "../../generated/testapi/W
 import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeIntegerTest";
 import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
 import { WithinRangeStringTest } from "../../generated/testapi/WithinRangeStringTest";
-import { WithinRangeString } from "italia-ts-commons/lib/strings";
-import { readableReport } from "italia-ts-commons/lib/reporters";
 
 const { generatedFilesDir, isSpecEnabled } = config.specs.testapi;
 
@@ -97,7 +97,7 @@ describe("Profile defintion", () => {
 });
 
 describe("WithinRangeIntegerTest defintion", () => {
-  //WithinRangeIntegerTest is defined min=0 max=10 in the spec
+  // WithinRangeIntegerTest is defined min=0 max=10 in the spec
   it.each`
     value        | expected
     ${0}         | ${true /* lower bound */}
@@ -119,7 +119,7 @@ describe("WithinRangeIntegerTest defintion", () => {
 });
 
 describe("WithinRangeNumberTest defintion", () => {
-  //WithinRangeNumberTest is defined min=0 max=10 in the spec
+  // WithinRangeNumberTest is defined min=0 max=10 in the spec
   it.each`
     value        | expected
     ${0}         | ${true /* lower bound */}
@@ -140,7 +140,7 @@ describe("WithinRangeNumberTest defintion", () => {
   );
 
   describe("WithinRangeExclusiveMinimumNumberTest definition", () => {
-    //WithinRangeExclusiveMinimumNumberTest is defined min=0 max=10 exclusiveMinimum: true in the spec
+    // WithinRangeExclusiveMinimumNumberTest is defined min=0 max=10 exclusiveMinimum: true in the spec
     it.each`
       value        | expected
       ${-1}        | ${false}
@@ -162,7 +162,7 @@ describe("WithinRangeNumberTest defintion", () => {
     );
   });
   describe("WithinRangeExclusiveMaximumNumberTest definition", () => {
-    //WithinRangeExclusiveMaximumNumberTest is defined min=0 max=10 exclusiveMaximum: true in the spec
+    // WithinRangeExclusiveMaximumNumberTest is defined min=0 max=10 exclusiveMaximum: true in the spec
     it.each`
       value        | expected
       ${0}         | ${true /* lower bound */}
@@ -171,7 +171,7 @@ describe("WithinRangeNumberTest defintion", () => {
       ${5.5}       | ${true}
       ${9}         | ${true}
       ${9.5}       | ${true}
-      ${10}        | ${false}
+      ${10}        | ${false /* upper bound */}
       ${11}        | ${false}
       ${100}       | ${false}
       ${undefined} | ${false}
@@ -184,7 +184,7 @@ describe("WithinRangeNumberTest defintion", () => {
     );
   });
 
-/*   it("should have correct ts types", () => {
+  /*   it("should have correct ts types", () => {
     // value is actually "any"
     const value1: WithinRangeNumberTest = WithinRangeNumberTest.decode(10).getOrElseL(err => {
       throw new Error(readableReport(err))
@@ -199,7 +199,7 @@ describe("WithinRangeNumberTest defintion", () => {
 });
 
 describe("WithinRangeExclusiveMinimumIntegerTest definition", () => {
-  //WithinRangeExclusiveMinimumIntegerTest is defined min=0 max=10 exclusiveMinimum: true in the spec
+  // WithinRangeExclusiveMinimumIntegerTest is defined min=0 max=10 exclusiveMinimum: true in the spec
   it.each`
     value        | expected
     ${0}         | ${false}
@@ -221,15 +221,15 @@ describe("WithinRangeExclusiveMinimumIntegerTest definition", () => {
 });
 
 describe("WithinRangeExclusiveMaximumIntegerTest definition", () => {
-  //WithinRangeExclusiveMaximumIntegerTest is defined min=0 max=10 exclusiveMaximum: true in the spec
+  // WithinRangeExclusiveMaximumIntegerTest is defined min=0 max=10 exclusiveMaximum: true in the spec
   it.each`
     value        | expected
     ${0}         | ${true /* lower bound */}
     ${-1}        | ${false}
     ${1}         | ${true}
     ${5}         | ${true}
-    ${9}         | ${true /* upper bound */}
-    ${10}        | ${false}
+    ${9}         | ${true}
+    ${10}        | ${false /* upper bound */}
     ${11}        | ${false}
     ${100}       | ${false}
     ${undefined} | ${false}
@@ -243,7 +243,7 @@ describe("WithinRangeExclusiveMaximumIntegerTest definition", () => {
 });
 
 describe("WithinRangeStringTest defintion", () => {
-  //WithinRangeStringTest is defined min=8 max=10 in the spec
+  // WithinRangeStringTest is defined min=8 max=10 in the spec
   it.each`
     value             | expected
     ${"a".repeat(7)}  | ${false}

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -8,6 +8,10 @@ import {
   IWithinRangeIntegerTag,
   IWithinRangeNumberTag
 } from "italia-ts-commons/lib/numbers";
+import { WithinRangeExclusiveMaximumIntegerTest } from "../../generated/testapi/WithinRangeExclusiveMaximumIntegerTest";
+import { WithinRangeExclusiveMaximumNumberTest } from "../../generated/testapi/WithinRangeExclusiveMaximumNumberTest";
+import { WithinRangeExclusiveMinimumIntegerTest } from "../../generated/testapi/WithinRangeExclusiveMinimumIntegerTest";
+import { WithinRangeExclusiveMinimumNumberTest } from "../../generated/testapi/WithinRangeExclusiveMinimumNumberTest";
 import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeIntegerTest";
 import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
 import { WithinRangeStringTest } from "../../generated/testapi/WithinRangeStringTest";
@@ -135,6 +139,51 @@ describe("WithinRangeNumberTest defintion", () => {
     }
   );
 
+  describe("WithinRangeExclusiveMinimumNumberTest definition", () => {
+    //WithinRangeExclusiveMinimumNumberTest is defined min=0 max=10 exclusiveMinimum: true in the spec
+    it.each`
+      value        | expected
+      ${-1}        | ${false}
+      ${0}         | ${false}
+      ${0.1}       | ${false}
+      ${1}         | ${true}
+      ${9.9999999} | ${true}
+      ${10}        | ${true /* upper bound */}
+      ${10.000001} | ${false}
+      ${11}        | ${false}
+      ${100}       | ${false}
+      ${undefined} | ${false}
+    `(
+      "should decode $value with WithinRangeExclusiveMinimumNumberTest",
+      ({ value, expected }) => {
+        const result = WithinRangeExclusiveMinimumNumberTest.decode(value);
+        expect(result.isRight()).toEqual(expected);
+      }
+    );
+  });
+  describe("WithinRangeExclusiveMaximumNumberTest definition", () => {
+    //WithinRangeExclusiveMaximumNumberTest is defined min=0 max=10 exclusiveMaximum: true in the spec
+    it.each`
+      value        | expected
+      ${0}         | ${true /* lower bound */}
+      ${-1}        | ${false}
+      ${1.5}       | ${true}
+      ${5.5}       | ${true}
+      ${9}         | ${true}
+      ${9.5}       | ${true}
+      ${10}        | ${false}
+      ${11}        | ${false}
+      ${100}       | ${false}
+      ${undefined} | ${false}
+    `(
+      "should decode $value with WithinRangeExclusiveMaximumNumberTest",
+      ({ value, expected }) => {
+        const result = WithinRangeExclusiveMaximumNumberTest.decode(value);
+        expect(result.isRight()).toEqual(expected);
+      }
+    );
+  });
+
 /*   it("should have correct ts types", () => {
     // value is actually "any"
     const value1: WithinRangeNumberTest = WithinRangeNumberTest.decode(10).getOrElseL(err => {
@@ -147,6 +196,50 @@ describe("WithinRangeNumberTest defintion", () => {
     const asRangedValue2: 10 = value1;
     const asRangedValue5: WithinRangeNumberTest = 10;
   }) */
+});
+
+describe("WithinRangeExclusiveMinimumIntegerTest definition", () => {
+  //WithinRangeExclusiveMinimumIntegerTest is defined min=0 max=10 exclusiveMinimum: true in the spec
+  it.each`
+    value        | expected
+    ${0}         | ${false}
+    ${-1}        | ${false}
+    ${1}         | ${true /* lower bound */}
+    ${5}         | ${true}
+    ${9}         | ${true}
+    ${10}        | ${true /* upper bound */}
+    ${11}        | ${false}
+    ${100}       | ${false}
+    ${undefined} | ${false}
+  `(
+    "should decode $value with WithinRangeExclusiveMinimumIntegerTest",
+    ({ value, expected }) => {
+      const result = WithinRangeExclusiveMinimumIntegerTest.decode(value);
+      expect(result.isRight()).toEqual(expected);
+    }
+  );
+});
+
+describe("WithinRangeExclusiveMaximumIntegerTest definition", () => {
+  //WithinRangeExclusiveMaximumIntegerTest is defined min=0 max=10 exclusiveMaximum: true in the spec
+  it.each`
+    value        | expected
+    ${0}         | ${true /* lower bound */}
+    ${-1}        | ${false}
+    ${1}         | ${true}
+    ${5}         | ${true}
+    ${9}         | ${true /* upper bound */}
+    ${10}        | ${false}
+    ${11}        | ${false}
+    ${100}       | ${false}
+    ${undefined} | ${false}
+  `(
+    "should decode $value with WithinRangeExclusiveMaximumIntegerTest",
+    ({ value, expected }) => {
+      const result = WithinRangeExclusiveMaximumIntegerTest.decode(value);
+      expect(result.isRight()).toEqual(expected);
+    }
+  );
 });
 
 describe("WithinRangeStringTest defintion", () => {

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -14,6 +14,8 @@ import { WithinRangeExclusiveMaximumIntegerTest } from "../../generated/testapi/
 import { WithinRangeExclusiveMaximumNumberTest } from "../../generated/testapi/WithinRangeExclusiveMaximumNumberTest";
 import { WithinRangeExclusiveMinimumIntegerTest } from "../../generated/testapi/WithinRangeExclusiveMinimumIntegerTest";
 import { WithinRangeExclusiveMinimumNumberTest } from "../../generated/testapi/WithinRangeExclusiveMinimumNumberTest";
+import { WithinRangeExclusiveMinMaxNumberTest } from "../../generated/testapi/WithinRangeExclusiveMinMaxNumberTest";
+
 import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeIntegerTest";
 import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
 import { WithinRangeStringTest } from "../../generated/testapi/WithinRangeStringTest";
@@ -145,7 +147,8 @@ describe("WithinRangeNumberTest defintion", () => {
       value        | expected
       ${-1}        | ${false}
       ${0}         | ${false}
-      ${0.1}       | ${false}
+      ${0.1}       | ${true}
+      ${0.5}       | ${true}
       ${1}         | ${true}
       ${9.9999999} | ${true}
       ${10}        | ${true /* upper bound */}
@@ -165,13 +168,14 @@ describe("WithinRangeNumberTest defintion", () => {
     // WithinRangeExclusiveMaximumNumberTest is defined min=0 max=10 exclusiveMaximum: true in the spec
     it.each`
       value        | expected
-      ${0}         | ${true /* lower bound */}
       ${-1}        | ${false}
+      ${0}         | ${true /* lower bound */}
       ${1.5}       | ${true}
       ${5.5}       | ${true}
       ${9}         | ${true}
       ${9.5}       | ${true}
-      ${10}        | ${false /* upper bound */}
+      ${9.999}     | ${true}
+      ${10}        | ${false}
       ${11}        | ${false}
       ${100}       | ${false}
       ${undefined} | ${false}
@@ -184,6 +188,30 @@ describe("WithinRangeNumberTest defintion", () => {
     );
   });
 
+  describe("WithinRangeExclusiveMinMaxNumberTest definition", () => {
+    // WithinRangeExclusiveMinMaxNumberTest is defined min=0 max=10 exclusiveMaximum: true exclusiveMinimum: true in the spec
+    it.each`
+      value        | expected
+      ${-1}        | ${false}
+      ${0}         | ${false}
+      ${0.1}       | ${true}
+      ${1.5}       | ${true}
+      ${5.5}       | ${true}
+      ${9}         | ${true}
+      ${9.5}       | ${true}
+      ${9.999}     | ${true}
+      ${10}        | ${false}
+      ${11}        | ${false}
+      ${100}       | ${false}
+      ${undefined} | ${false}
+    `(
+      "should decode $value with WithinRangeExclusiveMinMaxNumberTest",
+      ({ value, expected }) => {
+        const result = WithinRangeExclusiveMinMaxNumberTest.decode(value);
+        expect(result.isRight()).toEqual(expected);
+      }
+    );
+  });
   /*   it("should have correct ts types", () => {
     // value is actually "any"
     const value1: WithinRangeNumberTest = WithinRangeNumberTest.decode(10).getOrElseL(err => {

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -70,13 +70,56 @@
  #}
 {% macro defineNumber(definitionName, definition, inline = false) -%}
   {% if definition.minimum != undefined and definition.maximum != undefined %}
-    {% set minimum = definition.minimum + 1 if definition.exclusiveMinimum else definition.minimum %}
-    {% set maximum = definition.maximum - 1 if definition.exclusiveMaximum else definition.maximum %}
     {{- 'import { IWithinRangeNumberTag, WithinRangeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
-    {% set typedef %}t.union([
-      WithinRangeNumber<{{ minimum }}, {{ maximum }}, IWithinRangeNumberTag<{{ minimum }}, {{ maximum }}>>({{ minimum }}, {{ maximum }}),
-      t.literal({{ maximum }})
-    ]){% endset %}
+    {% if definition.minimum != undefined and definition.maximum != undefined %}
+      {## [R,L)  #}
+      {% if definition.exclusiveMaximum and not definition.exclusiveMinimum %}
+        {% set typedef %}
+          WithinRangeNumber<{{ definition.minimum }}, {{ definition.maximum }}, IWithinRangeNumberTag<{{ definition.minimum }}, {{ definition.maximum }}>>({{ definition.minimum }}, {{ definition.maximum }})
+        {% endset %}
+      {## (R,L]  #}  
+      {% elif definition.exclusiveMinimum and not definition.exclusiveMaximum %}
+        {% set typedef %}const WithoutExclusive = t.union([
+          WithinRangeNumber<{{ definition.minimum }}, {{ definition.maximum }}, IWithinRangeNumberTag<{{ definition.minimum }}, {{ definition.maximum }}>>({{ definition.minimum }}, {{ definition.maximum }}),
+          t.literal({{ definition.maximum }})
+        ]){% endset %}
+        {{ defineConst(undefined, 'WithoutExclusive', typedef, false, true) }}
+        {% set typedef %}
+        t.brand(
+          WithoutExclusive,
+          (
+            n
+          ): n is t.Branded<
+            t.TypeOf<typeof WithoutExclusive>,
+            { readonly {{ definitionName }}: symbol }
+          > => n != {{ definition.minimum }},
+          "{{definitionName}}"
+        );
+        {% endset %}
+      {## (R,L)  #}
+      {% elif definition.exclusiveMaximum and definition.exclusiveMinimum %}
+        {% set typedef %}const WithoutExclusive = WithinRangeNumber<{{ definition.minimum }}, {{ definition.maximum }}, IWithinRangeNumberTag<{{ definition.minimum }}, {{ definition.maximum }}>>({{ definition.minimum }}, {{ definition.maximum }}){% endset %}
+        {{ defineConst(undefined, 'WithoutExclusive', typedef, false, true) }}
+        {% set typedef %}
+        t.brand(
+          WithoutExclusive,
+          (
+            n
+          ): n is t.Branded<
+            t.TypeOf<typeof WithoutExclusive>,
+            { readonly {{ definitionName }}: symbol }
+          > => n != {{ definition.minimum }},
+          "{{definitionName}}"
+        );
+        {% endset %}
+      {## [R,L]  #}  
+      {% else %}
+        {% set typedef %}t.union([
+          WithinRangeNumber<{{ definition.minimum }}, {{ definition.maximum }}, IWithinRangeNumberTag<{{ definition.minimum }}, {{ definition.maximum }}>>({{ definition.minimum }}, {{ definition.maximum }}),
+          t.literal({{ definition.maximum }})
+        ]){% endset %}
+      {% endif %}
+    {% endif %}
   {% elif definition.minimum == "0" %}
     {{- 'import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
     {% set typedef %}NonNegativeNumber{% endset %}

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -70,10 +70,12 @@
  #}
 {% macro defineNumber(definitionName, definition, inline = false) -%}
   {% if definition.minimum != undefined and definition.maximum != undefined %}
+    {% set minimum = definition.minimum + 1 if definition.exclusiveMinimum else definition.minimum %}
+    {% set maximum = definition.maximum - 1 if definition.exclusiveMaximum else definition.maximum %}
     {{- 'import { IWithinRangeNumberTag, WithinRangeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
     {% set typedef %}t.union([
-      WithinRangeNumber<{{ definition.minimum }}, {{ definition.maximum }}, IWithinRangeNumberTag<{{ definition.minimum }}, {{ definition.maximum }}>>({{ definition.minimum }}, {{ definition.maximum }}),
-      t.literal({{ definition.maximum }})
+      WithinRangeNumber<{{ minimum }}, {{ maximum }}, IWithinRangeNumberTag<{{ minimum }}, {{ maximum }}>>({{ minimum }}, {{ maximum }}),
+      t.literal({{ maximum }})
     ]){% endset %}
   {% elif definition.minimum == "0" %}
     {{- 'import { NonNegativeNumber } from "italia-ts-commons/lib/numbers";' | addImport -}}
@@ -89,10 +91,12 @@
  #}
 {% macro defineInteger(definitionName, definition, inline = false) -%}
   {% if definition.minimum != undefined and definition.maximum != undefined %}
+    {% set minimum = definition.minimum + 1 if definition.exclusiveMinimum else definition.minimum %}
+    {% set maximum = definition.maximum - 1 if definition.exclusiveMaximum else definition.maximum %}
     {{- 'import { IWithinRangeIntegerTag, WithinRangeInteger } from "italia-ts-commons/lib/numbers";' | addImport -}}
     {% set typedef %}t.union([
-      WithinRangeInteger<{{ definition.minimum }}, {{ definition.maximum }}, IWithinRangeIntegerTag<{{ definition.minimum }}, {{ definition.maximum }}>>({{ definition.minimum }}, {{ definition.maximum }}),
-      t.literal({{ definition.maximum }})
+      WithinRangeInteger<{{ minimum }}, {{ maximum }}, IWithinRangeIntegerTag<{{ minimum }}, {{ maximum }}>>({{ minimum }}, {{ maximum }}),
+      t.literal({{ maximum }})
     ]){% endset %}
   {% elif definition.minimum == "0" %}
     {{- 'import { NonNegativeInteger } from "italia-ts-commons/lib/numbers";' | addImport -}}


### PR DESCRIPTION
This PR introduces the management of `exclusiveMaximum` and `exclusiveMinimum`  for integer and number data type.

According to OpenAPI specification, the minimum and maximum values are included in the range and  to exclude the boundary values, is required to specify `exclusiveMinimum: true` and `exclusiveMaximum: true`.

The word “exclusive” in exclusiveMinimum and exclusiveMaximum means the corresponding boundary is excluded:

Keyword | Description
-- | --
exclusiveMinimum: false or not included | value ≥ minimum
exclusiveMinimum: true | value > minimum
exclusiveMaximum: false or not included | value ≤ maximum
exclusiveMaximum: true | value < maximum

**Example**

If we have the following definition:

```yaml
  WithinRangeExclusiveMinimumIntegerTest:
    title: WithinRangeIntegerTest
    type: integer
    minimum: 0
    exclusiveMinimum: true
    maximum: 10
```

the following model will be generated:
```ts
import {
  IWithinRangeIntegerTag,
  WithinRangeInteger
} from "italia-ts-commons/lib/numbers";
import * as t from "io-ts";

export type WithinRangeExclusiveMinimumIntegerTest = t.TypeOf<
  typeof WithinRangeExclusiveMinimumIntegerTest
>;
export const WithinRangeExclusiveMinimumIntegerest = t.union([
  WithinRangeInteger<1, 10, IWithinRangeIntegerTag<1, 10>>(1, 10),
  t.literal(10)
]);
```