### PR TITLE
[#175498392] Handle enum for boolean type in openapi definition

### DIFF
--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -308,7 +308,49 @@ definitions:
       flag:
         type: boolean
         enum:
-          - true 
+          - true
+  EnumFalseTest:
+    type: object
+    properties:
+      flag:
+        type: boolean
+        enum:
+          - false
+  EnabledUserTest:
+    type: object
+    properties:
+      description:
+        type: string   
+      enabled:
+        type: boolean
+        enum:
+          - true
+      username:
+        type: string
+    required:
+      - enabled 
+      - description
+      - username
+  DisabledUserTest:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+        enum:
+          - false
+      reason:
+         type: string    
+      username:
+        type: string
+    required:
+      - enabled
+      - reason 
+      - username      
+  DisjointUnionsUserTest: 
+    x-one-of: true
+    allOf:
+      - $ref: "#/definitions/EnabledUserTest"
+      - $ref: "#/definitions/DisabledUserTest"                 
   MessageContent:
     type: object
     properties:

--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -308,15 +308,7 @@ definitions:
       flag:
         type: boolean
         enum:
-          - true
-  EnumTrueFalseTest:
-    type: object
-    properties:
-      flag:
-        type: boolean
-        enum:
-          - true      
-          - false       
+          - true 
   MessageContent:
     type: object
     properties:

--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -302,6 +302,21 @@ definitions:
           - value1
           - value2
           - value3
+  EnumTrueTest:
+    type: object
+    properties:
+      flag:
+        type: boolean
+        enum:
+          - true
+  EnumTrueFalseTest:
+    type: object
+    properties:
+      flag:
+        type: boolean
+        enum:
+          - true      
+          - false       
   MessageContent:
     type: object
     properties:

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -20,6 +20,8 @@ import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeInteg
 import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
 import { WithinRangeStringTest } from "../../generated/testapi/WithinRangeStringTest";
 
+import { DisjointUnionsUserTest } from "../../generated/testapi/DisjointUnionsUserTest";
+import { EnumFalseTest } from "../../generated/testapi/EnumFalseTest";
 import { EnumTrueTest } from "../../generated/testapi/EnumTrueTest";
 
 const { generatedFilesDir, isSpecEnabled } = config.specs.testapi;
@@ -302,6 +304,57 @@ describe("EnumTrueTest definition", () => {
 
   it("should not decode statusKo with EnumTrueTest", () => {
     const result = EnumTrueTest.decode(statusKo);
+
+    expect(result.isLeft()).toBe(true);
+  });
+});
+
+describe("EnumFalseTest definition", () => {
+  const statusOk = { flag: false };
+  const statusKo = { flag: true };
+
+  it("should decode statusOk with EnumFalseTest", () => {
+    const result = EnumFalseTest.decode(statusOk);
+    expect(result.isRight()).toBe(true);
+  });
+
+  it("should not decode statusKo with EnumFalseTest", () => {
+    const result = EnumFalseTest.decode(statusKo);
+
+    expect(result.isLeft()).toBe(true);
+  });
+});
+
+describe("DisjointUnionsUserTest definition", () => {
+  const enabledUser = {
+    description: "Description for the user",
+    enabled: true,
+    username: "user"
+  };
+  const disabledUser = {
+    enabled: false,
+    reason: "reason for the user",
+    username: "user"
+  };
+
+  const invalidUser = {
+    description: "Description for the user",
+    enabled: false,
+    username: "user"
+  };
+
+  it("should decode enabledUser with DisjointUnionsUserTest", () => {
+    const result = DisjointUnionsUserTest.decode(enabledUser);
+    expect(result.isRight()).toBe(true);
+  });
+
+  it("should decode disabledUser with DisjointUnionsUserTest", () => {
+    const result = DisjointUnionsUserTest.decode(disabledUser);
+    expect(result.isRight()).toBe(true);
+  });
+
+  it("should not decode invalidUser with DisjointUnionsUserTest", () => {
+    const result = DisjointUnionsUserTest.decode(invalidUser);
 
     expect(result.isLeft()).toBe(true);
   });

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -20,7 +20,9 @@ import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeInteg
 import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
 import { WithinRangeStringTest } from "../../generated/testapi/WithinRangeStringTest";
 
+import { DisabledUserTest } from "../../generated/testapi/DisabledUserTest";
 import { DisjointUnionsUserTest } from "../../generated/testapi/DisjointUnionsUserTest";
+import { EnabledUserTest } from "../../generated/testapi/EnabledUserTest";
 import { EnumFalseTest } from "../../generated/testapi/EnumFalseTest";
 import { EnumTrueTest } from "../../generated/testapi/EnumTrueTest";
 
@@ -344,18 +346,32 @@ describe("DisjointUnionsUserTest definition", () => {
   };
 
   it("should decode enabledUser with DisjointUnionsUserTest", () => {
-    const result = DisjointUnionsUserTest.decode(enabledUser);
-    expect(result.isRight()).toBe(true);
+    const userTest = DisjointUnionsUserTest.decode(enabledUser);
+    const enabledUserTest = EnabledUserTest.decode(enabledUser);
+    const disabledUserTest = DisabledUserTest.decode(enabledUser);
+
+    expect(userTest.isRight()).toBe(true);
+    expect(enabledUserTest.isRight()).toBe(true);
+    expect(disabledUserTest.isLeft()).toBe(true);
   });
 
   it("should decode disabledUser with DisjointUnionsUserTest", () => {
-    const result = DisjointUnionsUserTest.decode(disabledUser);
-    expect(result.isRight()).toBe(true);
+    const userTest = DisjointUnionsUserTest.decode(disabledUser);
+    const enabledUserTest = EnabledUserTest.decode(disabledUser);
+    const disabledUserTest = DisabledUserTest.decode(disabledUser);
+
+    expect(userTest.isRight()).toBe(true);
+    expect(disabledUserTest.isRight()).toBe(true);
+    expect(enabledUserTest.isLeft()).toBe(true);
   });
 
   it("should not decode invalidUser with DisjointUnionsUserTest", () => {
-    const result = DisjointUnionsUserTest.decode(invalidUser);
+    const userTest = DisjointUnionsUserTest.decode(invalidUser);
+    const enabledUserTest = EnabledUserTest.decode(invalidUser);
+    const disabledUserTest = DisabledUserTest.decode(invalidUser);
 
-    expect(result.isLeft()).toBe(true);
+    expect(userTest.isLeft()).toBe(true);
+    expect(disabledUserTest.isLeft()).toBe(true);
+    expect(enabledUserTest.isLeft()).toBe(true);
   });
 });

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -20,7 +20,6 @@ import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeInteg
 import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
 import { WithinRangeStringTest } from "../../generated/testapi/WithinRangeStringTest";
 
-import { EnumTrueFalseTest } from "../../generated/testapi/EnumTrueFalseTest";
 import { EnumTrueTest } from "../../generated/testapi/EnumTrueTest";
 
 const { generatedFilesDir, isSpecEnabled } = config.specs.testapi;

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -20,6 +20,9 @@ import { WithinRangeIntegerTest } from "../../generated/testapi/WithinRangeInteg
 import { WithinRangeNumberTest } from "../../generated/testapi/WithinRangeNumberTest";
 import { WithinRangeStringTest } from "../../generated/testapi/WithinRangeStringTest";
 
+import { EnumTrueFalseTest } from "../../generated/testapi/EnumTrueFalseTest";
+import { EnumTrueTest } from "../../generated/testapi/EnumTrueTest";
+
 const { generatedFilesDir, isSpecEnabled } = config.specs.testapi;
 
 // if there's no need for this suite in this particular run, just skip it
@@ -287,4 +290,36 @@ describe("WithinRangeStringTest defintion", () => {
       expect(result.isRight()).toEqual(expected);
     }
   );
+});
+
+describe("EnumTrueTest definition", () => {
+  const statusOk = { flag: true };
+  const statusKo = { flag: false };
+
+  it("should decode statusOk with EnumTrueTest", () => {
+    const result = EnumTrueTest.decode(statusOk);
+    expect(result.isRight()).toBe(true);
+  });
+
+  it("should not decode statusKo with EnumTrueTest", () => {
+    const result = EnumTrueTest.decode(statusKo);
+
+    expect(result.isLeft()).toBe(true);
+  });
+});
+
+describe("EnumTrueFalseTest definition", () => {
+  const statusTrue = { flag: true };
+  const statusFalse = { flag: false };
+
+  it("should decode statusTrue with EnumTrueFalseTest", () => {
+    const result = EnumTrueFalseTest.decode(statusTrue);
+    expect(result.isRight()).toBe(true);
+  });
+
+  it("should decode statusFalse with EnumTrueFalseTest", () => {
+    const result = EnumTrueFalseTest.decode(statusFalse);
+
+    expect(result.isRight()).toBe(true);
+  });
 });

--- a/e2e/src/__tests__/test-api/definitions.test.ts
+++ b/e2e/src/__tests__/test-api/definitions.test.ts
@@ -307,19 +307,3 @@ describe("EnumTrueTest definition", () => {
     expect(result.isLeft()).toBe(true);
   });
 });
-
-describe("EnumTrueFalseTest definition", () => {
-  const statusTrue = { flag: true };
-  const statusFalse = { flag: false };
-
-  it("should decode statusTrue with EnumTrueFalseTest", () => {
-    const result = EnumTrueFalseTest.decode(statusTrue);
-    expect(result.isRight()).toBe(true);
-  });
-
-  it("should decode statusFalse with EnumTrueFalseTest", () => {
-    const result = EnumTrueFalseTest.decode(statusFalse);
-
-    expect(result.isRight()).toBe(true);
-  });
-});

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -215,18 +215,8 @@
  # defines a boolean property
  #}
 {% macro defineBoolean(definitionName, definition, inline = false) -%}
-  {% if definition["enum"] %}    
-    {% if definition["enum"] | length == 1 %}
-      {% set typedef %}t.literal({{definition["enum"][0]}}){% endset %}
-    {% elif definition["enum"] | length > 1 %}
-      {% set typedef %}
-        t.union([
-        {% for enum in definition["enum"] %}
-          t.literal({{enum}}),
-        {% endfor %}
-        ])
-      {% endset %}
-    {% endif %}
+  {% if definition["enum"] and definition["enum"] | length == 1%}    
+    {% set typedef %}t.literal({{definition["enum"][0]}}){% endset %}
   {% else %}
     {% set typedef %}t.boolean{% endset %}
   {% endif %}

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -215,7 +215,21 @@
  # defines a boolean property
  #}
 {% macro defineBoolean(definitionName, definition, inline = false) -%}
-  {% set typedef %}t.boolean{% endset %}
+  {% if definition["enum"] %}    
+    {% if definition["enum"] | length == 1 %}
+      {% set typedef %}t.literal({{definition["enum"][0]}}){% endset %}
+    {% elif definition["enum"] | length > 1 %}
+      {% set typedef %}
+        t.union([
+        {% for enum in definition["enum"] %}
+          t.literal({{enum}}),
+        {% endfor %}
+        ])
+      {% endset %}
+    {% endif %}
+  {% else %}
+    {% set typedef %}t.boolean{% endset %}
+  {% endif %}
   {{ defineConst(definition.default, definitionName, typedef, false, inline) }}
 {% endmacro %}
 


### PR DESCRIPTION
This PR introduces the management of `enum` keyword also for `boolean` type.

This feature is useful for example when you want to define an object in which a property is always true or false:

```yaml
  EnumTrueTest:
    type: object
    properties:
      flag:
        type: boolean
        enum:
          - true
```

The definition generated:

```ts
import * as t from "io-ts";

// required attributes
const EnumTrueTestR = t.interface({});

// optional attributes
const EnumTrueTestO = t.partial({
  flag: t.literal(true)
});

export const EnumTrueTest = t.exact(
  t.intersection([EnumTrueTestR, EnumTrueTestO], "EnumTrueTest")
);

export type EnumTrueTest = t.TypeOf<typeof EnumTrueTest>;
```