### PR TITLE
Test case: using custom decoder

### DIFF
--- a/e2e/src/__tests__/test-api/request-types.test.ts
+++ b/e2e/src/__tests__/test-api/request-types.test.ts
@@ -5,6 +5,14 @@ import * as requestTypes from "../../generated/testapi/requestTypes";
 
 // @ts-ignore because leaked-handles doesn't ship type defintions
 import * as leaked from "leaked-handles";
+import {
+  createFetchRequestForApi,
+  ReplaceRequestParams,
+  RequestParams,
+  TypeofApiCall
+} from "@pagopa/ts-commons/lib/requests";
+import { options } from "yargs";
+import { right } from "fp-ts/lib/Either";
 leaked.set({ debugSockets: true });
 
 const { isSpecEnabled } = config.specs.testapi;
@@ -187,5 +195,66 @@ describeSuite("Request types generated from Test API spec", () => {
         }
       }
     );
+  });
+
+  describe("use custom decoder", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    // just a fetch instance that always return the default success status
+    const defaultSuccessStatus = 201;
+    const mockFetch = ((() => ({
+      status: defaultSuccessStatus,
+      json: async () => ({})
+    })) as unknown) as typeof fetch;
+
+    // just pick one of the response decoders we generate, any will do
+    const aDecoderFactory = requestTypes.testParameterWithReferenceDecoder;
+    type aRequestType = requestTypes.TestParameterWithReferenceT;
+
+    // just a mock decoder that always successfully decode
+    // only constraint: DecoderType must extend response decoder for the default status code
+    type DecoderType = undefined;
+    const mockIs = jest.fn<boolean, [unknown]>(_ => true);
+    const mockDecode = jest.fn(e => right<t.Errors, DecoderType>(e));
+    const mockEncode = jest.fn(e => e);
+    const aCustomDecoder = new t.Type<DecoderType, DecoderType, unknown>(
+      "CustomDecoder",
+      (mockIs as unknown) as t.Is<DecoderType>,
+      mockDecode,
+      mockEncode
+    );
+
+    it.each`
+      testName                       | decoder
+      ${"with explicit declaration"} | ${aDecoderFactory({ [defaultSuccessStatus]: aCustomDecoder })}
+      ${"with implicit declaration"} | ${aDecoderFactory(aCustomDecoder)}
+    `("should use custom decoder $testName", async ({ decoder }) => {
+      const apiRequestT: ReplaceRequestParams<
+        aRequestType,
+        RequestParams<aRequestType>
+      > = {
+        method: "post",
+        headers: () => ({
+          "Content-Type": "application/json"
+        }),
+        response_decoder: decoder,
+        url: ({}) => `/any/path`,
+        body: () => "any body",
+        query: () => ({})
+      };
+
+      const apiRequest: TypeofApiCall<aRequestType> = createFetchRequestForApi(
+        apiRequestT,
+        {
+          fetchApi: mockFetch
+        }
+      );
+
+      const result = await apiRequest({});
+      expect(mockDecode).toBeCalled();
+      expect(result.isRight()).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
This PR introduces no changes but a failing test. It serves to demonstrate the existence of a bug spotted in https://github.com/pagopa/io-app/pull/2717. It adds 2 test:
1. using a custom decoder by passing it as an explicit `<statusCode, responseDecoder>` map
1. using a custom decoder by passing with an implicit interface, assuming it's going to be mapped to the default success status code.

#### Results
While the first test passes, the second fails. I understand this happens because the generated `requestTypes` modules ships a function `isDecoder` which is wrong in determining if the value passed is a decoder or a map of decoders; by failing this, it erroneously treat a single decoder as a map of decoders, hence the bug.
[Here](https://github.com/pagopa/io-utils/blob/0e897950ea0f2730e6915f4ef08cf3d929fd0fde/src/commands/gen-api-models/render.ts#L318) the implementation.

#### Proposed solution
provide a working `isDecoder` implamentation

#### Mitigation
Just use an explicit decoder map.
Please note that, given a `aCustomDecoder` decoder and a request with `status` as a default success status code,  the following two instructions build the very same response decoder:
```ts
const responseDecoderA = myRequestDecoder(aCustomDecoder);
const responseDecoderB = myRequestDecoder({ [status]: aCustomDecoder });
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
E2E test suites

