### PR TITLE
[#176997929] Remove SafeIdentifier on query param names

### DIFF
--- a/__mocks__/api.yaml
+++ b/__mocks__/api.yaml
@@ -136,6 +136,27 @@ paths:
         "200":
           description: "Ok"
         "500":
+          description: "Fatal error" 
+  /test-parameter-with-dash-and_underscore/{path-param}:
+    get:
+      operationId: "testParameterWithDashAnUnderscore"
+      parameters:
+        - name: path-param
+          in: path
+          type: string
+        - name: foo_bar
+          in: query
+          type: string
+        - name: headerInlineParam
+          in: header
+          type: string
+          required: true
+        - $ref: "#/parameters/RequestId"
+        - $ref: "#/parameters/HeaderParamWithReference"
+      responses:
+        "200":
+          description: "Ok"
+        "500":
           description: "Fatal error"    
   /test-two-path-params/{first-param}/{second-param}:
     get:

--- a/e2e/src/__tests__/test-api/client.test.ts
+++ b/e2e/src/__tests__/test-api/client.test.ts
@@ -70,4 +70,23 @@ describeSuite("Http client generated from Test API spec", () => {
     });
     expect(isRight(result)).toBe(true);
   });
+
+  it("should handle both parameter with dashes and underscores", async () => {
+    const client = createClient({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: (nodeFetch as any) as typeof fetch,
+      basePath: ""
+    });
+
+    expect(client.testParameterWithDashAnUnderscore).toEqual(expect.any(Function));
+
+    const result = await client.testParameterWithDashAnUnderscore({
+      "foo_bar": "value",
+      headerInlineParam: "value",
+      "path-param": "value",
+      "request-id": "value",
+      "x-header-param": "value"
+    });
+    expect(isRight(result)).toBe(true);
+  });
 });

--- a/e2e/src/__tests__/test-api/client.test.ts
+++ b/e2e/src/__tests__/test-api/client.test.ts
@@ -1,3 +1,4 @@
+import * as url from "url";
 import { isRight } from "fp-ts/lib/Either";
 import nodeFetch from "node-fetch";
 import config from "../../config";
@@ -78,15 +79,73 @@ describeSuite("Http client generated from Test API spec", () => {
       basePath: ""
     });
 
-    expect(client.testParameterWithDashAnUnderscore).toEqual(expect.any(Function));
+    expect(client.testParameterWithDashAnUnderscore).toEqual(
+      expect.any(Function)
+    );
 
     const result = await client.testParameterWithDashAnUnderscore({
-      "foo_bar": "value",
+      foo_bar: "value",
       headerInlineParam: "value",
       "path-param": "value",
       "request-id": "value",
       "x-header-param": "value"
     });
     expect(isRight(result)).toBe(true);
+  });
+
+  it("should not edit parameter names", async () => {
+    // given a spied fetch call, check if the request has been made using the provided parameter in querystring
+    const hasQueryParam = (paramName: string) => ([input]: Parameters<
+      typeof fetch
+    >) => {
+      const inputUrl = typeof input === "string" ? input : input.url;
+      const parsedUrl = url.parse(inputUrl);
+      return parsedUrl.query && ~parsedUrl.query.indexOf(paramName);
+    };
+
+    // given a spied fetch call, check if the request has been made using the provided header parameter
+    const hasHeaderParam = (paramName: string) => ([, init]: Parameters<
+      typeof fetch
+    >) => {
+      return init && init.headers && paramName in init.headers;
+    };
+
+    const spiedFetch = jest.fn<
+      ReturnType<typeof fetch>,
+      Parameters<typeof fetch>
+    >((nodeFetch as any) as typeof fetch);
+
+    const client = createClient({
+      baseUrl: `http://localhost:${mockPort}`,
+      fetchApi: spiedFetch,
+      basePath: ""
+    });
+
+    expect(client.testParameterWithDash).toEqual(expect.any(Function));
+
+    const result = await client.testParameterWithDash({
+      "foo-bar": "value",
+      headerInlineParam: "value",
+      "path-param": "value",
+      "request-id": "value",
+      "x-header-param": "value"
+    });
+
+    expect(spiedFetch).toHaveBeenCalledTimes(1);
+    // Because of a bug, we used to edit parameter names into camelCased ones, but they must be uses as they are named in the
+    // The following ensures we're doing the right thing now
+    expect(hasQueryParam("foo-bar")(spiedFetch.mock.calls[0])).toBeTruthy();
+    expect(hasQueryParam("fooBar")(spiedFetch.mock.calls[0])).toBeFalsy();
+    expect(hasQueryParam("request-id")(spiedFetch.mock.calls[0])).toBeTruthy();
+    expect(hasQueryParam("requestId")(spiedFetch.mock.calls[0])).toBeFalsy();
+    expect(
+      hasHeaderParam("x-header-param")(spiedFetch.mock.calls[0])
+    ).toBeTruthy();
+    expect(
+      hasHeaderParam("xHeaderParam")(spiedFetch.mock.calls[0])
+    ).toBeFalsy();
+    expect(
+      hasHeaderParam("headerInlineParam")(spiedFetch.mock.calls[0])
+    ).toBeTruthy();
   });
 });

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -730,6 +730,8 @@ import {
   testParameterWithReferenceDefaultDecoder,
   TestParameterWithDashT,
   testParameterWithDashDefaultDecoder,
+  TestParameterWithDashAnUnderscoreT,
+  testParameterWithDashAnUnderscoreDefaultDecoder,
   TestWithTwoParamsT,
   testWithTwoParamsDefaultDecoder
 } from \\"./requestTypes\\";
@@ -747,6 +749,7 @@ export type ApiOperation = TypeofApiCall<TestAuthBearerT> &
   TypeofApiCall<TestResponseHeaderT> &
   TypeofApiCall<TestParameterWithReferenceT> &
   TypeofApiCall<TestParameterWithDashT> &
+  TypeofApiCall<TestParameterWithDashAnUnderscoreT> &
   TypeofApiCall<TestWithTwoParamsT>;
 
 export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
@@ -756,6 +759,7 @@ export type ParamKeys = keyof (TypeofApiParams<TestAuthBearerT> &
   TypeofApiParams<TestResponseHeaderT> &
   TypeofApiParams<TestParameterWithReferenceT> &
   TypeofApiParams<TestParameterWithDashT> &
+  TypeofApiParams<TestParameterWithDashAnUnderscoreT> &
   TypeofApiParams<TestWithTwoParamsT>);
 
 /**
@@ -787,6 +791,7 @@ export type WithDefaultsT<
   | TestResponseHeaderT
   | TestParameterWithReferenceT
   | TestParameterWithDashT
+  | TestParameterWithDashAnUnderscoreT
   | TestWithTwoParamsT,
   K
 >;
@@ -814,6 +819,10 @@ export type Client<
       >;
 
       readonly testParameterWithDash: TypeofApiCall<TestParameterWithDashT>;
+
+      readonly testParameterWithDashAnUnderscore: TypeofApiCall<
+        TestParameterWithDashAnUnderscoreT
+      >;
 
       readonly testWithTwoParams: TypeofApiCall<TestWithTwoParamsT>;
     }
@@ -864,6 +873,13 @@ export type Client<
         ReplaceRequestParams<
           TestParameterWithDashT,
           Omit<RequestParams<TestParameterWithDashT>, K>
+        >
+      >;
+
+      readonly testParameterWithDashAnUnderscore: TypeofApiCall<
+        ReplaceRequestParams<
+          TestParameterWithDashAnUnderscoreT,
+          Omit<RequestParams<TestParameterWithDashAnUnderscoreT>, K>
         >
       >;
 
@@ -1072,6 +1088,37 @@ export function createClient<K extends ParamKeys>({
     options
   );
 
+  const testParameterWithDashAnUnderscoreT: ReplaceRequestParams<
+    TestParameterWithDashAnUnderscoreT,
+    RequestParams<TestParameterWithDashAnUnderscoreT>
+  > = {
+    method: \\"get\\",
+
+    headers: ({
+      [\\"headerInlineParam\\"]: headerInlineParam,
+      [\\"x-header-param\\"]: xHeaderParam
+    }: {
+      headerInlineParam: string;
+      \\"x-header-param\\": string;
+    }) => ({
+      headerInlineParam: headerInlineParam,
+
+      \\"x-header-param\\": xHeaderParam
+    }),
+    response_decoder: testParameterWithDashAnUnderscoreDefaultDecoder(),
+    url: ({ [\\"path-param\\"]: pathParam }) =>
+      \`\${basePath}/test-parameter-with-dash-and_underscore/\${pathParam}\`,
+
+    query: ({ [\\"foo_bar\\"]: fooBar, [\\"request-id\\"]: requestId }) => ({
+      [\\"foo_bar\\"]: fooBar,
+      [\\"request-id\\"]: requestId
+    })
+  };
+  const testParameterWithDashAnUnderscore: TypeofApiCall<TestParameterWithDashAnUnderscoreT> = createFetchRequestForApi(
+    testParameterWithDashAnUnderscoreT,
+    options
+  );
+
   const testWithTwoParamsT: ReplaceRequestParams<
     TestWithTwoParamsT,
     RequestParams<TestWithTwoParamsT>
@@ -1101,6 +1148,9 @@ export function createClient<K extends ParamKeys>({
       testParameterWithReference
     ),
     testParameterWithDash: (withDefaults || identity)(testParameterWithDash),
+    testParameterWithDashAnUnderscore: (withDefaults || identity)(
+      testParameterWithDashAnUnderscore
+    ),
     testWithTwoParams: (withDefaults || identity)(testWithTwoParams)
   };
 }

--- a/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/commands/gen-api-models/__tests__/__snapshots__/index.test.ts.snap
@@ -929,9 +929,9 @@ export function createClient<K extends ParamKeys>({
     url: ({}) => \`\${basePath}/test-auth-bearer\`,
 
     query: ({ [\\"qo\\"]: qo, [\\"qr\\"]: qr, [\\"cursor\\"]: cursor }) => ({
-      qo,
-      qr,
-      cursor
+      [\\"qo\\"]: qo,
+      [\\"qr\\"]: qr,
+      [\\"cursor\\"]: cursor
     })
   };
   const testAuthBearer: TypeofApiCall<TestAuthBearerT> = createFetchRequestForApi(
@@ -952,9 +952,9 @@ export function createClient<K extends ParamKeys>({
     url: ({}) => \`\${basePath}/test-simple-token\`,
 
     query: ({ [\\"qo\\"]: qo, [\\"qr\\"]: qr, [\\"cursor\\"]: cursor }) => ({
-      qo,
-      qr,
-      cursor
+      [\\"qo\\"]: qo,
+      [\\"qr\\"]: qr,
+      [\\"cursor\\"]: cursor
     })
   };
   const testSimpleToken: TypeofApiCall<TestSimpleTokenT> = createFetchRequestForApi(
@@ -1063,8 +1063,8 @@ export function createClient<K extends ParamKeys>({
       \`\${basePath}/test-parameter-with-dash/\${pathParam}\`,
 
     query: ({ [\\"foo-bar\\"]: fooBar, [\\"request-id\\"]: requestId }) => ({
-      fooBar,
-      requestId
+      [\\"foo-bar\\"]: fooBar,
+      [\\"request-id\\"]: requestId
     })
   };
   const testParameterWithDash: TypeofApiCall<TestParameterWithDashT> = createFetchRequestForApi(

--- a/templates/client.ts.njk
+++ b/templates/client.ts.njk
@@ -145,7 +145,7 @@ export function createClient<K extends ParamKeys>({
     body: () => "{}",
     {% endif %}
     {% if queryParams | length %}
-    query: ({ {{ queryParams | pick("name") | stripQuestionMark | safeDestruct | join(', ') | safe }} }) => ({ {{ queryParams | pick("name") | stripQuestionMark | safeIdentifier | join(", ") | safe  }} }),
+    query: ({ {{ queryParams | pick("name") | stripQuestionMark | safeDestruct | join(', ') | safe }} }) => ({ {{ queryParams | pick("name") | stripQuestionMark | safeDestruct | join(", ") | safe  }} }),
     {% else %}
     query: () => ({}),
     {% endif %}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Description
<!--- Describe your changes in detail -->
Remove `safeIdentifier` transformation on query param names, prefer `safeDestruct` instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Since auto-generated client parses in query params spec as camelCased properties, we remove this default behavior due to a possible mismatch on query param names that are kebab-based or snake-cased.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests.
#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (improvement with no change in the behaviour)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
